### PR TITLE
Return the HTMLElement for convenience.

### DIFF
--- a/src/main/kotlin/net/yested/core/html/html.kt
+++ b/src/main/kotlin/net/yested/core/html/html.kt
@@ -3,10 +3,11 @@ package net.yested.core.html
 import org.w3c.dom.*
 import kotlin.browser.document
 
-fun <T : HTMLElement> tag(parent: Element, tagName: String, init:(T.()->Unit)? = null) {
+fun <T : HTMLElement> tag(parent: Element, tagName: String, init:(T.()->Unit)? = null): T {
     val element:T = document.createElement(tagName).asDynamic()
     parent.appendChild(element)
     init?.let { element.init() }
+    return element
 }
 
 fun HTMLElement.div(init:(HTMLDivElement.()->Unit)? = null) = tag(this, tagName = "div", init = init)

--- a/src/main/kotlin/net/yested/ext/bootstrap3/buttons.kt
+++ b/src/main/kotlin/net/yested/ext/bootstrap3/buttons.kt
@@ -79,7 +79,6 @@ enum class Orientation(val code: String) {
 }
 
 fun HTMLDivElement.generateDropdownInto(label: String, init: DropDownContext.() -> Unit) {
-    var el: HTMLUListElement? = null
     button {
         className = "btn btn-default dropdown-toggle"; type = "button"
         setAttribute("data-toggle", "dropdown")
@@ -87,11 +86,8 @@ fun HTMLDivElement.generateDropdownInto(label: String, init: DropDownContext.() 
         plus(" ")
         span { className = "caret" }
     }
-    ul {
-        className = "dropdown-menu"
-        el = this
-    }
-    DropDownContext(el!!).init()
+    val el = ul { className = "dropdown-menu" }
+    DropDownContext(el).init()
 }
 
 fun HTMLElement.dropdown(
@@ -147,11 +143,8 @@ class ButtonGroupContext(val context: HTMLElement) {
 }
 
 fun HTMLElement.buttonGroup(size: ButtonGroupSize = ButtonGroupSize.Default, init: ButtonGroupContext.()->Unit) {
-    var el: HTMLElement? = null
-    div { className = "btn-group ${size.code}"
-        el = this
-    }
-    ButtonGroupContext(el!!).init()
+    val el = div { className = "btn-group ${size.code}" }
+    ButtonGroupContext(el).init()
 }
 
 class ButtonToolbarContext(val size: ButtonGroupSize = ButtonGroupSize.Default, val context: HTMLElement) {
@@ -161,9 +154,6 @@ class ButtonToolbarContext(val size: ButtonGroupSize = ButtonGroupSize.Default, 
 }
 
 fun HTMLElement.buttonToolbar(size: ButtonGroupSize = ButtonGroupSize.Default, init: ButtonToolbarContext.()->Unit) {
-    var el: HTMLElement? = null
-    div { className = "btn-toolbar"
-        el = this
-    }
-    ButtonToolbarContext(size = size, context = el!!).init()
+    val el = div { className = "btn-toolbar" }
+    ButtonToolbarContext(size = size, context = el).init()
 }

--- a/src/main/kotlin/net/yested/ext/bootstrap3/inputgroup.kt
+++ b/src/main/kotlin/net/yested/ext/bootstrap3/inputgroup.kt
@@ -63,10 +63,7 @@ class InputGroupContext(val el: HTMLDivElement) {
 }
 
 fun HTMLElement.inputGroup(size: InputGroupSize = InputGroupSize.Default, init: InputGroupContext.()->Unit) {
-    var el: HTMLDivElement? = null
-    div { className = "input-group ${size.code}"
-       el = this
-    }
-    InputGroupContext(el!!).init()
+    val el = div { className = "input-group ${size.code}" }
+    InputGroupContext(el).init()
 }
 

--- a/src/main/kotlin/net/yested/ext/bootstrap3/navbar.kt
+++ b/src/main/kotlin/net/yested/ext/bootstrap3/navbar.kt
@@ -59,9 +59,8 @@ class NavbarMenu(val ul: HTMLUListElement) {
                     plus(label)
                     span { className = "caret" }
                 }
-                ul {
+                el = ul {
                     className = "dropdown-menu"
-                    el = this
                 }
             }
         }

--- a/src/main/kotlin/net/yested/ext/bootstrap3/navs.kt
+++ b/src/main/kotlin/net/yested/ext/bootstrap3/navs.kt
@@ -44,9 +44,6 @@ enum class TabsFormat(val code: String) {
 }
 
 fun HTMLElement.navTabs(format: TabsFormat = TabsFormat.Tabs, justified: Boolean = false, init: NavContext.()->Unit) {
-    var el:HTMLUListElement? = null
-    ul { className = "nav ${format.code} ${if (justified) "nav-justified" else ""}"
-       el = this
-    }
-    NavContext(el!!).init()
+    val el = ul { className = "nav ${format.code} ${if (justified) "nav-justified" else ""}" }
+    NavContext(el).init()
 }


### PR DESCRIPTION
This replaces the need for this ugly construct in simple cases:

```
var el: HTMLDivElement? = null
div { className = "input-group ${size.code}"
   el = this
}
InputGroupContext(el!!).init()
```

and replaces it with:
    val el = div { className = "input-group ${size.code}" }
    InputGroupContext(el).init()

In more complex cases where a nested element is needed, the former construct is still necessary.
