### PR TITLE
Make JS library compatible with kotlin 1.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,11 +98,6 @@
                         <configuration>
                             <target>
                                 <copy todir="${project.build.outputDirectory}">
-                                    <fileset dir="${basedir}/src/main/kotlin">
-                                        <include name="**/*.kt"/>
-                                    </fileset>
-                                </copy>
-                                <copy todir="${project.build.outputDirectory}">
                                     <fileset dir="${project.build.directory}/js">
                                         <include name="*.js"/>
                                     </fileset>
@@ -126,7 +121,6 @@
                         <forced/>
                         <manifestEntries>
                             <Implementation-Version>${build.number}</Implementation-Version>
-                            <Specification-Title>Kotlin JavaScript Lib</Specification-Title>
                             <Kotlin-JS-Module-Name>${project.artifactId}</Kotlin-JS-Module-Name>
                         </manifestEntries>
                     </archive>


### PR DESCRIPTION
See https://discuss.kotlinlang.org/t/using-a-custom-kotlin-javascript-library-from-a-kotlin-javascript-project/2118/4