### PR TITLE
Extract generic tablecontent.kt from grid

### DIFF
--- a/src/main/kotlin/net/yested/core/properties/properties.kt
+++ b/src/main/kotlin/net/yested/core/properties/properties.kt
@@ -67,6 +67,44 @@ fun <IN, OUT> ReadOnlyProperty<IN>.mapAsDefault(transform: (IN)->OUT): Property<
     return property
 }
 
+/** Maps two properties together to calculate a single result. */
+fun <T,T2,OUT> ReadOnlyProperty<T>.mapWith(property2: ReadOnlyProperty<T2>, transform: (T,T2)->OUT): ReadOnlyProperty<OUT> {
+    var value1 = this.get()
+    var value2 = property2.get()
+    val result = Property(transform(value1, value2))
+    this.onNext {
+        value1 = it
+        result.set(transform(value1, value2))
+    }
+    property2.onNext {
+        value2 = it
+        result.set(transform(value1, value2))
+    }
+    return result
+}
+
+/** Maps three properties together to calculate a single result. */
+fun <T,T2,T3,OUT> ReadOnlyProperty<T>.mapWith(property2: ReadOnlyProperty<T2>, property3: ReadOnlyProperty<T3>,
+                                              transform: (T,T2,T3)->OUT): ReadOnlyProperty<OUT> {
+    var value1 = this.get()
+    var value2 = property2.get()
+    var value3 = property3.get()
+    val result = Property(transform(value1, value2, value3))
+    this.onNext {
+        value1 = it
+        result.set(transform(value1, value2, value3))
+    }
+    property2.onNext {
+        value2 = it
+        result.set(transform(value1, value2, value3))
+    }
+    property3.onNext {
+        value3 = it
+        result.set(transform(value1, value2, value3))
+    }
+    return result
+}
+
 /**
  * Map a Property to another Property and vice-versa.
  * This is useful when either property can be modified and the other property should reflect the change,

--- a/src/main/kotlin/net/yested/core/properties/properties.kt
+++ b/src/main/kotlin/net/yested/core/properties/properties.kt
@@ -1,5 +1,6 @@
 package net.yested.core.properties
 
+import net.yested.core.utils.SortSpecification
 import java.util.*
 
 interface Disposable {
@@ -232,6 +233,10 @@ fun <T> Property<List<T>>.modifyList(operation: (ArrayList<T>) -> Unit) {
 fun <T> Property<List<T>>.clear() { modifyList { it.clear() } }
 fun <T> Property<List<T>>.removeAt(index: Int) { modifyList { it.removeAt(index) } }
 fun <T> Property<List<T>>.add(item: T) { modifyList { it.add(item) } }
+
+fun <T> ReadOnlyProperty<Iterable<T>?>.sortedWith(sortSpecification: ReadOnlyProperty<SortSpecification<T>?>): ReadOnlyProperty<Iterable<T>?> {
+    return sortedWith(sortSpecification.map { it?.fullComparator })
+}
 
 fun <T> ReadOnlyProperty<Iterable<T>?>.sortedWith(comparator: ReadOnlyProperty<Comparator<T>?>): ReadOnlyProperty<Iterable<T>?> {
     return mapWith(comparator) { toSort, comparator ->

--- a/src/main/kotlin/net/yested/core/utils/functional.kt
+++ b/src/main/kotlin/net/yested/core/utils/functional.kt
@@ -1,6 +1,8 @@
 package net.yested.core.utils
 
 import net.yested.core.properties.Property
+import java.util.*
+import kotlin.comparisons.compareBy
 import kotlin.comparisons.compareValues
 
 infix fun <T> T.with(doWith: T.()->Unit): T {
@@ -15,4 +17,9 @@ fun <T, V : Comparable<V>> compareByValue(get: (T) -> V?): (T, T) -> Int {
 /** Compare two Property values.  This is especially useful when using a grid of Iterable<Property<T>>. */
 fun <T, V : Comparable<V>> compareByPropertyValue(get: (T) -> V?): (Property<T>, Property<T>) -> Int {
     return compareByValue<Property<T>,V> { get(it.get()) }
+}
+
+/** Compare two Property values.  This is especially useful when using a grid of Iterable<Property<T>>. */
+fun <T> compareByProperty(get: (T) -> Comparable<*>?): Comparator<Property<T>> {
+    return compareBy { get(it.get()) }
 }

--- a/src/main/kotlin/net/yested/ext/bootstrap3/grid.kt
+++ b/src/main/kotlin/net/yested/ext/bootstrap3/grid.kt
@@ -2,8 +2,9 @@ package net.yested.ext.bootstrap3
 
 import net.yested.core.html.*
 import net.yested.core.properties.*
-import net.yested.core.utils.removeChildByName
-import net.yested.core.utils.with
+import net.yested.core.utils.SortSpecification
+import net.yested.core.utils.sortControl
+import net.yested.core.utils.tbody
 import org.w3c.dom.*
 import java.util.*
 
@@ -98,18 +99,29 @@ fun HTMLElement.col(width: ColumnDefinition, init: HTMLDivElement.()->Unit): HTM
     }
 }
 
-data class Column<in T>(
+/** Note: Here for backward-compatibility. */
+fun <T> Column(label: HTMLElement.() -> Unit,
+               sortFunction: ((T, T) -> Int)? = null,
+               align: Align = Align.LEFT,
+               sortAscending: Boolean? = null,
+               render: HTMLElement.(T) -> Unit): Column<T> {
+    val comparator: Comparator<T>? = sortFunction?.let { Comparator { obj1: T, obj2: T -> (it(obj1, obj2)) * (if (sortAscending!!) 1 else -1) } }
+    return Column(label, comparator, align, sortAscending, render)
+}
+
+/** Note: This would be <in T> except that Comparator isn't labeled as having <in T>. */
+data class Column<T>(
         val label: HTMLElement.() -> Unit,
-        val sortFunction: ((T, T) -> Int)? = null,
+        val comparator: Comparator<T>? = null,
         val align: Align = Align.LEFT,
         val sortAscending: Boolean? = null,
         val render: HTMLElement.(T) -> Unit) {
     init {
-        if ((sortFunction == null) != (sortAscending == null)) {
-            if (sortFunction == null) {
-                throw IllegalArgumentException("sortFunction must be specified when sortAscending is specified")
+        if ((comparator == null) != (sortAscending == null)) {
+            if (comparator == null) {
+                throw IllegalArgumentException("comparator must be specified when sortAscending is specified")
             } else {
-                throw IllegalArgumentException("sortAscending must be specified when sortFunction is specified")
+                throw IllegalArgumentException("sortAscending must be specified when comparator is specified")
             }
         }
     }
@@ -130,67 +142,55 @@ fun <T> HTMLElement.grid(responsive: Boolean = false, columns: Array<Column<T>>,
 private fun <T> HTMLElement.gridTable(columns: Array<Column<T>>, data: ReadOnlyProperty<Iterable<T>?>,
                                       sortColumn: Property<Column<T>?>) {
     data class ColumnSort<T>(val column: Column<T>, val ascending: Boolean) {
-        val comparator: Comparator<T>? = column.sortFunction?.let { Comparator { obj1: T, obj2: T -> (it(obj1, obj2)) * (if (ascending) 1 else -1) } }
+        val comparator: Comparator<T>? = column.comparator
     }
 
     val columnSort: Property<ColumnSort<T>?> = sortColumn.mapAsDefault { it?.let { ColumnSort(it, it.sortAscending!!) } }
-    val sortedData = data.sortedWith(columnSort.map { it?.comparator })
-
-    fun sortByColumn(column: Column<T>) {
-        if (column == sortColumn.get()) {
-            val currentColumnSort = columnSort.get()!!
-            columnSort.set(currentColumnSort.copy(ascending = !currentColumnSort.ascending))
-        } else {
-            sortColumn.set(column)
-        }
+    val sortSpecification: Property<SortSpecification<T>?> = columnSort.mapAsDefault {
+        if (it != null && it.comparator != null) SortSpecification(it.comparator, it.ascending) else null
     }
+    val sortedData = data.sortedWith(sortSpecification)
 
-    val tableElement = table() { className = "table table-striped table-hover table-condensed"
+    table { className = "table table-striped table-hover table-condensed"
         thead {
             tr {
                 columns.forEach { column ->
-                    th { className = "text-${column.align.code}"
-                        if (column.sortAscending == null) {
+                    th {
+                        className = "text-${column.align.code}"
+                        if (column.comparator == null) {
                             (column.label)()
                         } else {
-                            a {
-                                setAttribute("style", "cursor: pointer;")
-                                onclick = { sortByColumn(column) }
+                            sortControlWithArrow<T>(sortSpecification, column.comparator, column.sortAscending!!) {
                                 (column.label)()
                             }
-                            span {
-                                val element = this
-                                val icon = columnSort.map { currentColumnSort ->
-                                    element.hidden = currentColumnSort?.ascending == null
-                                    if (currentColumnSort?.column != column) null
-                                    else if (currentColumnSort!!.ascending) "arrow-up" else "arrow-down"
-                                }
-                                glyphicon(icon)
-                            }
                         }
                     }
                 }
             }
         }
+        tbody(sortedData) { item ->
+            tr {
+                columns.forEach { column ->
+                    td {
+                        className = "text-${column.align.code}"
+                        (column.render)(item)
+                    }
+                }
+            }
+        }
     }
+}
 
-    sortedData.onNext { values ->
-        tableElement.removeChildByName("tbody")
-        values?.let {
-            tableElement.with {
-                tbody {
-                    values.forEach { item ->
-                        tr {
-                            columns.forEach { column ->
-                                td {
-                                    className = "text-${column.align.code}"
-                                    (column.render)(item)
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+fun <T> HTMLTableHeaderCellElement.sortControlWithArrow(currentSort: Property<SortSpecification<T>?>,
+                                                        comparator: Comparator<T>, sortAscending: Boolean = true,
+                                                        sortNow: Boolean = false, init: HTMLElement.() -> Unit): Property<Boolean?> {
+    val ascendingProperty = sortControl(currentSort, comparator, sortAscending, sortNow, init)
+    span {
+        val icon = ascendingProperty.map { ascending ->
+            hidden = ascending == null
+            if (ascending == null) null else if (ascending) "arrow-up" else "arrow-down"
         }
+        glyphicon(icon)
     }
+    return ascendingProperty
 }

--- a/src/test/kotlin/demo.kt
+++ b/src/test/kotlin/demo.kt
@@ -1,10 +1,15 @@
 import net.yested.core.html.*
 import net.yested.core.properties.*
+import net.yested.core.utils.SortSpecification
+import net.yested.core.utils.tbody
 import net.yested.core.utils.with
 import net.yested.ext.bootstrap3.*
 import org.w3c.dom.HTMLElement
 import kotlin.browser.document
+import kotlin.comparisons.compareBy
+import kotlin.comparisons.naturalOrder
 import kotlin.dom.appendText
+import kotlin.dom.onClick
 
 enum class City { Prague, London }
 
@@ -230,7 +235,7 @@ fun main(args: Array<String>) {
             }
         }
 
-        /*textInput(value = p, validation = validation)
+        /*textInput(value = p, validation = validation)*/
         div {
             id = "id"
             className = "bla"
@@ -241,12 +246,8 @@ fun main(args: Array<String>) {
         table {
             thead {
                 tr {
-                    th {
-                        appendText("Col1")
-                    }
-                    th {
-                        appendText("Col2")
-                    }
+                    th { appendText("Col1") }
+                    th { appendText("Col2") }
                 }
             }
             tbody {
@@ -254,24 +255,34 @@ fun main(args: Array<String>) {
                     td {
                         a {
                             appendText("http://www.seznam.cz")
-                            onClick {
-                                js("alert('hh')")
-                            }
+                            onClick { js("alert('hh')") }
                         }
                     }
+                    td { text(p) }
                     td {
-                        text(p)
-                    }
-                    td {
-                        selectInput(selected = city, options = Property(City.values().toList()), render = { appendText(it.name) })
+                        singleSelectInput(selected = city, options = Property(City.values().toList()), render = { appendText(it.name) })
                         appendText("Selected city: ")
                         text(value = city.map { it.name })
                     }
                 }
             }
-        }*/
+        }
+        val currentSort = Property<SortSpecification<String>?>(null)
+        table {
+            thead {
+                tr {
+                    th { sortControlWithArrow(currentSort, naturalOrder<String>()) { appendText("URL") } }
+                    th { sortControlWithArrow(currentSort, compareBy<String> { parseInt(it) }) { appendText("URL Length") } }
+                }
+            }
+            tbody(listOf("http://www.seznam.cz", "http://www.google.com", "http://www.yahoo.com").toProperty().sortedWith(currentSort)) { index, value ->
+                tr { className = if (index % 2 == 0) "even" else "odd"
+                    td { appendText(value) }
+                    td { appendText(value.length.toString()) }
+                }
+            }
+        }
     }
-
 }
 
 fun openSampleDialog() {

--- a/src/test/kotlin/net/yested/core/properties/PropertyTest.kt
+++ b/src/test/kotlin/net/yested/core/properties/PropertyTest.kt
@@ -85,6 +85,39 @@ class PropertyTest {
     }
 
     @Test
+    fun mapWith() {
+        val int1Property = 123.toProperty()
+        val int2Property = 456.toProperty()
+        val textProperty = int1Property.mapWith(int2Property) { int1, int2 ->
+            "" + int1 + int2
+        }
+        textProperty.get().mustBe("123456")
+
+        int1Property.set(999)
+        textProperty.get().mustBe("999456")
+
+        int2Property.set(555)
+        textProperty.get().mustBe("999555")
+    }
+
+    @Test
+    fun mapWith_2() {
+        val int1Property = 123.toProperty()
+        val int2Property = 456.toProperty()
+        val int3Property = 789.toProperty()
+        val textProperty = int1Property.mapWith(int2Property, int3Property) { int1, int2, int3 ->
+            "" + int1 + int2 + int3
+        }
+        textProperty.get().mustBe("123456789")
+
+        int1Property.set(999)
+        textProperty.get().mustBe("999456789")
+
+        int3Property.set(555)
+        textProperty.get().mustBe("999456555")
+    }
+
+    @Test
     fun bind_shouldUpdateTheNewProperty() {
         val intProperty = 123.toProperty()
         val textProperty = intProperty.bind(

--- a/src/test/kotlin/net/yested/core/utils/SortControlTest.kt
+++ b/src/test/kotlin/net/yested/core/utils/SortControlTest.kt
@@ -1,0 +1,70 @@
+package net.yested.core.utils
+
+import net.yested.core.html.*
+import net.yested.core.properties.*
+import org.junit.Test
+import spec.*
+import kotlin.comparisons.compareBy
+import kotlin.dom.appendText
+
+/**
+ * A test for [sortControl].
+ * @author Eric Pabst (epabst@gmail.com)
+ * Date: 9/29/16
+ * Time: 1:51 PM
+ */
+class SortControlTest {
+    data class Person(val name: String, val age: Int)
+
+    @Test
+    fun shouldSortAsExpected() {
+        var nameSort : Property<Boolean?>? = null
+        var ageSort : Property<Boolean?>? = null
+        val currentSort = Property<SortSpecification<Person>?>(null)
+        val data = listOf(Person("George", 40), Person("Ancient Billy", 90), Person("Buddy", 7)).toProperty()
+        val sortedData = data.sortedWith(currentSort)
+        Div {
+            table {
+                thead {
+                    th {
+                        nameSort = sortControl(currentSort, compareBy { it.name }) {
+                            appendText("Name")
+                        }
+                    }
+                    th {
+                        ageSort = sortControl(currentSort, compareBy { it.age }) {
+                            appendText("Age")
+                        }
+                    }
+                }
+                tbody(sortedData) { item ->
+                }
+            }
+        }
+        sortedData.get()?.map { it.name }.mustBe(listOf("George", "Ancient Billy", "Buddy"))
+
+        nameSort!!.set(true)
+        sortedData.get()?.map { it.name }.mustBe(listOf("Ancient Billy", "Buddy", "George"))
+
+        ageSort!!.set(true)
+        nameSort!!.get().mustBe(null)
+        sortedData.get()?.map { it.name }.mustBe(listOf("Buddy", "George", "Ancient Billy"))
+
+        nameSort!!.get().mustBe(null)
+        nameSort!!.set(null) // should be a no-op since already null
+        sortedData.get()?.map { it.name }.mustBe(listOf("Buddy", "George", "Ancient Billy"))
+
+        nameSort!!.set(false)
+        ageSort!!.get().mustBe(null)
+        sortedData.get()?.map { it.name }.mustBe(listOf("George", "Buddy", "Ancient Billy"))
+
+        nameSort!!.set(true)
+        sortedData.get()?.map { it.name }.mustBe(listOf("Ancient Billy", "Buddy", "George"))
+
+        nameSort!!.set(false)
+        sortedData.get()?.map { it.name }.mustBe(listOf("George", "Buddy", "Ancient Billy"))
+
+        nameSort!!.set(null)
+        sortedData.get()?.map { it.name }.mustBe(listOf("George", "Ancient Billy", "Buddy"))
+    }
+}


### PR DESCRIPTION
This replaces grid with an approach that is much more consistent with the rest of yested and kotlin.
It is also not tied in any way to bootstrap so that it can work with any CSS approach.

Add Property.mapWith
Add ReadOnlyProperty.detectContentChange()