### PR TITLE
Extract prepareDialog.

### DIFF
--- a/src/test/kotlin/demo.kt
+++ b/src/test/kotlin/demo.kt
@@ -291,7 +291,7 @@ fun openSampleDialog() {
             appendText("sample text")
         }}
         footer {
-            btsButton(look = ButtonLook.Primary, onclick = { dialog.closeDialog() }) {
+            btsButton(look = ButtonLook.Primary, onclick = { dialog.hideDialog() }) {
                 appendText("Submit")
             }
         }


### PR DESCRIPTION
Rename DialogInterface to DialogControl.
This makes it reusable so that multiple copies of a given dialog don't need to be created.
Instead, the consuming code can show and hide the dialog as many as times as it wants to.