### PR TITLE
Add window.location.hashProperty and backToHash

### DIFF
--- a/src/main/kotlin/net/yested/core/properties/properties.kt
+++ b/src/main/kotlin/net/yested/core/properties/properties.kt
@@ -33,7 +33,11 @@ class Property<T>(initialValue: T): ReadOnlyProperty<T> {
         if (newValue != value || newValueHashCode != valueHashCode) {
             value = newValue
             valueHashCode = newValueHashCode
-            listeners.forEach { it.onNext(value) }
+            listeners.forEach {
+                if ((value == newValue) && (valueHashCode == newValueHashCode)) {
+                    it.onNext(value)
+                } //else one of the listeners or another thread may have changed it again, which will have its own notification
+            }
         }
     }
 

--- a/src/main/kotlin/net/yested/ext/bootstrap3/navbar.kt
+++ b/src/main/kotlin/net/yested/ext/bootstrap3/navbar.kt
@@ -1,7 +1,6 @@
 package net.yested.ext.bootstrap3
 
 import net.yested.core.html.setClassPresence
-import net.yested.core.html.setDisabled
 import net.yested.core.html.*
 import net.yested.core.properties.Property
 import net.yested.core.properties.ReadOnlyProperty
@@ -125,14 +124,9 @@ class NavbarContext(
             active: Property<Boolean>? = null,
             disabled: ReadOnlyProperty<Boolean>? = null,
             init: HTMLButtonElement.()->Unit) {
-        contentElement.btsButton { className = "btn navbar-btn ${position.code} btn-${look.code}"; type = "submit"
-            addEventListener("click", {  event ->
-                onclick?.let { onclick(event) }
-                active?.set(!active.get())
-            }, false)
+        contentElement.btsButton(look = look, onclick = onclick, active = active, disabled = disabled) {
+            addClass("navbar-btn", position.code)
             init()
-            active?.let { setClassPresence("active", it) }
-            disabled?.let { setDisabled(it) }
         }
     }
 

--- a/src/main/kotlin/net/yested/ext/jquery/router.kt
+++ b/src/main/kotlin/net/yested/ext/jquery/router.kt
@@ -69,6 +69,11 @@ fun History.backToHash(hashUrl: String?) {
         console.info("Going back to $hashUrl")
     }
     historyDestinationBack = hashUrl
+    backToDestination()
+}
+
+private fun History.backToDestination() {
+    val hashUrl = historyDestinationBack
     if (window.location.hash == "") {
         console.info("got to the main entry-point page.  Assuming it's close enough to '$hashUrl'")
         historyDestinationBack = null
@@ -82,23 +87,19 @@ fun History.backToHash(hashUrl: String?) {
         console.info("got to the beginning of browser history going to $hashUrl")
         windowLocationHash.set(hashUrl)
     } else {
-        //The onNext listener above will see if it needs to go back again
+        window.setTimeout({
+            val destinationBack = window.history.destinationBack
+            if (destinationBack != null) {
+                backToDestination()
+            }
+        }, 100)
         back()
     }
 }
 
-/** A place to store the current destination going back, outside of the [backToHash] method. */
-private var historyDestinationBack: String? = makeDestinationBackBeActive()
+/**
+ * A place to store the current destination going back, outside of the [backToHash] method.
+ * It is only public to be accessible from tests in other projects.
+ */
 val History.destinationBack: String? get() = historyDestinationBack
-
-/** This onNext listener needs to be invoked before any custom listener to avoid drawing multiple pages as it goes back. */
-private fun makeDestinationBackBeActive(): String? {
-    windowLocationHash.onNext { hash ->
-        console.info("new window.location.hash=$hash")
-        val destinationBack = window.history.destinationBack
-        if (destinationBack != null) {
-            window.history.backToHash(destinationBack)
-        }
-    }
-    return null
-}
+private var historyDestinationBack: String? = null

--- a/src/main/kotlin/net/yested/ext/jquery/router.kt
+++ b/src/main/kotlin/net/yested/ext/jquery/router.kt
@@ -1,23 +1,63 @@
 package net.yested.ext.jquery
 
+import net.yested.core.properties.Property
+import net.yested.core.properties.bind
+import org.w3c.dom.Location
 import kotlin.browser.window
 
 @native
 private interface JQRouter {
     fun on(eventName:String, listener:() -> Unit):Unit = noImpl
+    fun trigger(eventName:String):Unit = noImpl
 }
 
 @native("$(window)") private var routerJQuery: JQRouter = null!!
 
-private fun getHashSplitted(): Array<String> {
-    return window.location.hash.split("_").toTypedArray()
+/** A Property for window.location.hash.  It is bound to [splitHashProperty]. */
+val Location.hashProperty: Property<String> get() = windowLocationHash
+private val windowLocationHash: Property<String> = window.location.bindToHash()
+
+/** A Property for window.location.hash as a split array.  It is bound to [hashProperty]. */
+val Location.splitHashProperty: Property<Array<String>> get() = splitWindowLocationHash
+private val splitWindowLocationHash: Property<Array<String>> = windowLocationHash.bind({ it.split("_").toTypedArray() }, { it.joinToString("_") })
+
+private fun Location.bindToHash(): Property<String> {
+    val property: Property<String> = Property(hash)
+    var updating = true // avoid triggering an onNext yet
+    routerJQuery.on("hashchange") {
+        if (!updating) {
+            updating = true
+            try {
+                property.set(hash)
+            } finally {
+                updating = false
+            }
+        }
+    }
+    property.onNext { newValue ->
+        if (!updating) {
+            updating = true
+            try {
+                routerJQuery.trigger("hashchange")
+            } finally {
+                updating = false
+            }
+        }
+    }
+    // enable the functionality
+    updating = false
+    return property
 }
 
+@Deprecated("If runNow is true, use window.location.splitHashProperty.onNext(listener) instead",
+        replaceWith = ReplaceWith("window.location.splitHashProperty.onNext(listener)"),
+        level = DeprecationLevel.WARNING)
 fun registerHashChangeListener(runNow:Boolean = true, listener:(Array<String>) -> Unit) {
-    routerJQuery.on("hashchange") {
-        listener(getHashSplitted())
-    }
     if (runNow) {
-        listener(getHashSplitted())
+        window.location.splitHashProperty.onNext { listener(it) }
+    } else {
+        routerJQuery.on("hashchange") {
+            listener(window.location.splitHashProperty.get())
+        }
     }
 }


### PR DESCRIPTION
Also add window.location.splitHashProperty that replaces registerHashChangeListener
using a Property.
Add History.backToHash that manages the browser history correctly, including browser back support.
Handle onNext callbacks calling Property.set gracefully, including tests.
