### PR TITLE
Make tbody animate and preserve HtmlTableRowElements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,30 @@
             </plugin>
 
             <plugin>
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+                <version>1.5.2</version>
+                <executions>
+                    <execution>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <file>target/test-js/Yested-tests.js</file>
+                        <replacements>
+                            <!-- add the QUnit assert parameter -->
+                            <replacement>
+                                <token>(HtmlBindTest.+\()(\)[ ;])</token>
+                                <value>$1assert$2</value>
+                            </replacement>
+                        </replacements>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
             </plugin>
 

--- a/src/main/kotlin/net/yested/core/html/html.kt
+++ b/src/main/kotlin/net/yested/core/html/html.kt
@@ -4,10 +4,12 @@ import org.w3c.dom.*
 import kotlin.browser.document
 import kotlin.dom.appendText
 
-fun <T : HTMLElement> tag(parent: Element, tagName: String, init:(T.()->Unit)? = null): T {
+fun <T : HTMLElement> tag(parent: Element, tagName: String,
+                          addFirst: Boolean = false, before: HTMLElement? = null, init:(T.()->Unit)? = null): T {
     val element:T = document.createElement(tagName).asDynamic()
-    parent.appendChild(element)
+    if (addFirst) parent.insertBefore(element, before)
     init?.let { element.init() }
+    if (!addFirst) parent.insertBefore(element, before)
     return element
 }
 
@@ -17,7 +19,8 @@ fun HTMLElement.nav(init:(HTMLDivElement.()->Unit)? = null) = tag(this, tagName 
 fun HTMLElement.span(init:(HTMLSpanElement.()->Unit)? = null) = tag(this, tagName = "span", init = init)
 fun HTMLElement.footer(init:(HTMLDivElement.()->Unit)? = null) = tag(this, tagName = "footer", init = init)
 fun HTMLElement.table(init:(HTMLTableElement.()->Unit)? = null) = tag(this, tagName = "table", init = init)
-fun HTMLElement.tr(init:(HTMLTableRowElement.()->Unit)? = null) = tag(this, tagName = "tr", init = init)
+fun HTMLElement.tr(addFirst: Boolean = false, before: HTMLElement? = null, init:(HTMLTableRowElement.()->Unit)? = null) =
+        tag(this, "tr", addFirst, before, init)
 fun HTMLElement.td(init:(HTMLTableCellElement.()->Unit)? = null) = tag(this, tagName = "td", init = init)
 fun HTMLElement.th(init:(HTMLTableHeaderCellElement.()->Unit)? = null) = tag(this, tagName = "th", init = init)
 fun HTMLElement.thead(init:(HTMLTableSectionElement.()->Unit)? = null) = tag(this, tagName = "thead", init = init)

--- a/src/main/kotlin/net/yested/core/html/htmlbind.kt
+++ b/src/main/kotlin/net/yested/core/html/htmlbind.kt
@@ -138,7 +138,7 @@ private fun <T> HTMLTableElement.setTBodyContentsImmediately(values: Iterable<T>
     return tbody {
         val tbody = this
         values?.forEachIndexed { index, item ->
-            TableItemContext({ rowInit -> tbody.tr(rowInit) }).tbodyItemInit(index, item)
+            TableItemContext({ rowInit -> tbody.tr(init = rowInit) }).tbodyItemInit(index, item)
         }
     }
 }
@@ -181,8 +181,7 @@ class TBodyOperableList<T>(initialData: MutableList<T>, val tbodyElement: HTMLTa
     override fun add(index: Int, item: T) {
         val nextRow = if (index < rowsWithoutDelays.size) rowsWithoutDelays.get(index) else null
         TableItemContext({ rowInit ->
-            val newRow = Tr(rowInit)
-            tbodyElement.insertBefore(newRow, nextRow)
+            val newRow = tbodyElement.tr(before = nextRow, init = rowInit)
             val jqNewRow = jq(newRow)
             // start it out hidden in a way that slideDown will show it.
             jqNewRow.slideUpTableRow(duration = 0) {

--- a/src/main/kotlin/net/yested/core/html/htmlbind.kt
+++ b/src/main/kotlin/net/yested/core/html/htmlbind.kt
@@ -1,10 +1,12 @@
 package net.yested.core.html
 
+import jquery.jq
 import net.yested.core.properties.Property
 import net.yested.core.properties.ReadOnlyProperty
 import net.yested.core.properties.bind
-import net.yested.core.utils.removeAllChildElements
-import net.yested.core.utils.removeChildByName
+import net.yested.core.utils.*
+import net.yested.ext.jquery.slideDownTableRow
+import net.yested.ext.jquery.slideUpTableRow
 import org.w3c.dom.*
 import kotlin.browser.document
 import kotlin.dom.addClass
@@ -108,14 +110,35 @@ fun HTMLInputElement.setReadOnly(property: ReadOnlyProperty<Boolean>) {
  *   }
  * </pre>
  */
-fun <T> HTMLTableElement.tbody(orderedData: ReadOnlyProperty<Iterable<T>?>, tbodyItemInit: TableItemContext.(Int, T)->Unit) {
-    orderedData.onNext { values ->
-        removeChildByName("tbody")
-        tbody {
-            val tbody = this
-            values?.forEachIndexed { index, item ->
-                TableItemContext(tbody).tbodyItemInit(index, item)
+fun <T> HTMLTableElement.tbody(orderedData: ReadOnlyProperty<Iterable<T>?>, animate: Boolean = true, tbodyItemInit: TableItemContext.(Int, T)->Unit) {
+    if (animate) {
+        var tbodyOperableList : TBodyOperableList<T>? = null
+
+        orderedData.onNext { values ->
+            val operableListSnapshot = tbodyOperableList
+            if (values == null) {
+                removeChildByName("tbody")
+                tbodyOperableList = null
+            } else if (operableListSnapshot == null) {
+                val tbody = setTBodyContentsImmediately(values, tbodyItemInit)
+                tbodyOperableList = TBodyOperableList(values.toMutableList(), tbody, tbodyItemInit)
+            } else {
+                operableListSnapshot.reconcileTo(values.toList())
             }
+        }
+    } else {
+        orderedData.onNext { values ->
+            setTBodyContentsImmediately(values, tbodyItemInit)
+        }
+    }
+}
+
+private fun <T> HTMLTableElement.setTBodyContentsImmediately(values: Iterable<T>?, tbodyItemInit: TableItemContext.(Int, T) -> Unit): HTMLTableSectionElement {
+    removeChildByName("tbody")
+    return tbody {
+        val tbody = this
+        values?.forEachIndexed { index, item ->
+            TableItemContext({ rowInit -> tbody.tr(rowInit) }).tbodyItemInit(index, item)
         }
     }
 }
@@ -137,20 +160,54 @@ fun <T> HTMLTableElement.tbody(orderedData: ReadOnlyProperty<Iterable<T>?>, tbod
  *   }
  * </pre>
  */
-fun <T> HTMLTableElement.tbody(orderedData: ReadOnlyProperty<Iterable<T>?>, tbodyItemInit: TableItemContext.(T)->Unit) {
-    orderedData.onNext { values ->
-        removeChildByName("tbody")
-        tbody {
-            val tbody = this
-            values?.forEach { item ->
-                TableItemContext(tbody).tbodyItemInit(item)
-            }
-        }
+fun <T> HTMLTableElement.tbody(orderedData: ReadOnlyProperty<Iterable<T>?>, animate: Boolean = true, tbodyItemInit: TableItemContext.(T)->Unit) {
+    return tbody(orderedData, animate) { index, item -> tbodyItemInit(item) }
+}
+
+class TableItemContext(private val rowFactory: ((HTMLTableRowElement.()->Unit)?)->HTMLTableRowElement) {
+    fun tr(init:(HTMLTableRowElement.()->Unit)? = null): HTMLTableRowElement {
+        return rowFactory.invoke(init)
     }
 }
 
-class TableItemContext(val tbody: HTMLTableSectionElement) {
-    fun tr(init:(HTMLTableRowElement.()->Unit)? = null): HTMLTableRowElement {
-        return tbody.tr(init)
+fun HTMLCollection.toList(): List<HTMLElement> {
+    return (0..(this.length - 1)).map { item(it)!! as HTMLElement }
+}
+
+class TBodyOperableList<T>(initialData: MutableList<T>, val tbodyElement: HTMLTableSectionElement,
+                           val tbodyItemInit: TableItemContext.(Int, T)->Unit) : InMemoryOperableList<T>(initialData) {
+    private val rowsWithoutDelays = tbodyElement.rows.toList().toMutableList()
+
+    override fun add(index: Int, item: T) {
+        TableItemContext({ rowInit ->
+            val insertIndex = if (index >= tbodyElement.rows.length) -1 else index
+            val newRow = tbodyElement.insertRow(insertIndex) as HTMLTableRowElement
+            rowsWithoutDelays.add(index, newRow)
+            if (rowInit != null) newRow.rowInit()
+            val jqNewRow = jq(newRow)
+            // start it out hidden in a way that slideDown will show it.
+            jqNewRow.slideUpTableRow(duration = 1) {
+                // now animate showing it
+                jqNewRow.slideDownTableRow()
+            }
+            newRow
+        }).tbodyItemInit(index, item)
+        super.add(index, item)
+    }
+
+    override fun removeAt(index: Int): T {
+        val row = rowsWithoutDelays.removeAt(index)
+        val jqRow = jq(row as HTMLTableRowElement)
+        jqRow.slideUpTableRow {
+            tbodyElement.removeChild(row)
+        }
+        return super.removeAt(index)
+    }
+
+    override fun move(fromIndex: Int, toIndex: Int) {
+        val item = removeAt(fromIndex)
+        add(toIndex, item)
+//        super.move(fromIndex, toIndex)
+//        (tbodyElement.parentElement as HTMLTableElement?)?.setTBodyContentsImmediately(toList(), tbodyItemInit)
     }
 }

--- a/src/main/kotlin/net/yested/core/html/htmlbind.kt
+++ b/src/main/kotlin/net/yested/core/html/htmlbind.kt
@@ -179,17 +179,17 @@ class TBodyOperableList<T>(initialData: MutableList<T>, val tbodyElement: HTMLTa
     private val rowsWithoutDelays = tbodyElement.rows.toList().toMutableList()
 
     override fun add(index: Int, item: T) {
+        val nextRow = if (index < rowsWithoutDelays.size) rowsWithoutDelays.get(index) else null
         TableItemContext({ rowInit ->
-            val insertIndex = if (index >= tbodyElement.rows.length) -1 else index
-            val newRow = tbodyElement.insertRow(insertIndex) as HTMLTableRowElement
-            rowsWithoutDelays.add(index, newRow)
-            if (rowInit != null) newRow.rowInit()
+            val newRow = Tr(rowInit)
+            tbodyElement.insertBefore(newRow, nextRow)
             val jqNewRow = jq(newRow)
             // start it out hidden in a way that slideDown will show it.
-            jqNewRow.slideUpTableRow(duration = 1) {
+            jqNewRow.slideUpTableRow(duration = 0) {
                 // now animate showing it
                 jqNewRow.slideDownTableRow()
             }
+            rowsWithoutDelays.add(index, newRow)
             newRow
         }).tbodyItemInit(index, item)
         super.add(index, item)

--- a/src/main/kotlin/net/yested/core/utils/OperableList.kt
+++ b/src/main/kotlin/net/yested/core/utils/OperableList.kt
@@ -60,7 +60,7 @@ fun <T> OperableList<T>.reconcileTo(desiredList: List<T>) {
     }
 }
 
-class InMemoryOperableList<T>(val list: MutableList<T>) : OperableList<T> {
+open class InMemoryOperableList<T>(val list: MutableList<T>) : OperableList<T> {
     var modificationCount = 0
 
     override fun size(): Int = list.size

--- a/src/main/kotlin/net/yested/core/utils/OperableList.kt
+++ b/src/main/kotlin/net/yested/core/utils/OperableList.kt
@@ -1,0 +1,85 @@
+package net.yested.core.utils
+
+/**
+ * A list that can be operated upon to clarify what kinds of animations should happen when updating it in a UI.
+ * @author Eric Pabst (epabst@gmail.com)
+ * Date: 4/4/2017
+ * Time: 11:49 PM
+ */
+interface OperableList<T> {
+    fun size(): Int
+    fun get(index: Int): T
+    fun add(index: Int, item: T)
+    fun removeAt(index: Int): T
+    fun move(fromIndex: Int, toIndex: Int)
+
+    fun indexOf(item: T): Int {
+       var index = size() - 1
+       while (index >= 0 && get(index) != item) {
+           index--
+       }
+       return index
+    }
+
+    fun contains(item: T): Boolean = indexOf(item) >= 0
+}
+
+fun <T> OperableList<T>.toList(): List<T> = range().map { get(it) }
+
+fun <T> OperableList<T>.range() = (0..(size() - 1))
+
+fun <T> OperableList<T>.reconcileTo(desiredList: List<T>) {
+    // delete anything that isn't in desiredList
+    range().reversed().forEach { if (!desiredList.contains(get(it))) removeAt(it) }
+    val (desiredListWithoutNew, newItems) = desiredList.partition { contains(it) }
+
+    var countMovingRight = 0
+    var countMovingLeft = 0
+    range().forEach { index ->
+        val desiredIndex = desiredListWithoutNew.indexOf(get(index))
+        if (desiredIndex > index) {
+            countMovingRight++
+        } else if (desiredIndex < index) {
+            countMovingLeft++
+        }
+    }
+    val desiredIndices = if (countMovingLeft <= countMovingRight) {
+        0..(desiredListWithoutNew.size - 1)
+    } else {
+        (0..(desiredListWithoutNew.size - 1)).reversed()
+    }
+    desiredIndices.forEach { desiredIndex ->
+        val desiredItem = desiredListWithoutNew[desiredIndex]
+        val indexToMove = indexOf(desiredItem)
+        if (indexToMove != desiredIndex) {
+            move(indexToMove, desiredIndex)
+        }
+    }
+    for (newItem in newItems) {
+        add(desiredList.indexOf(newItem), newItem)
+    }
+}
+
+class InMemoryOperableList<T>(val list: MutableList<T>) : OperableList<T> {
+    var modificationCount = 0
+
+    override fun size(): Int = list.size
+
+    override fun get(index: Int): T = list[index]
+
+    override fun add(index: Int, item: T) {
+        modificationCount++
+        list.add(index, item)
+    }
+
+    override fun removeAt(index: Int): T {
+        modificationCount++
+        return list.removeAt(index)
+    }
+
+    override fun move(fromIndex: Int, toIndex: Int) {
+        modificationCount++
+        val item = list.removeAt(fromIndex)
+        list.add(toIndex, item)
+    }
+}

--- a/src/main/kotlin/net/yested/core/utils/htmlutils.kt
+++ b/src/main/kotlin/net/yested/core/utils/htmlutils.kt
@@ -59,10 +59,3 @@ fun Div(init:(HTMLDivElement.()->Unit)? = null): HTMLDivElement {
     init?.let { element.init() }
     return element
 }
-
-/** Creates a TR that is not attached to any parent HTMLElement yet. */
-fun Tr(init:(HTMLTableRowElement.()->Unit)? = null): HTMLTableRowElement {
-    val element: HTMLTableRowElement = document.createElement("tr").asDynamic()
-    init?.let { element.init() }
-    return element
-}

--- a/src/main/kotlin/net/yested/core/utils/htmlutils.kt
+++ b/src/main/kotlin/net/yested/core/utils/htmlutils.kt
@@ -2,6 +2,7 @@ package net.yested.core.utils
 
 import org.w3c.dom.HTMLDivElement
 import org.w3c.dom.HTMLElement
+import org.w3c.dom.HTMLTableRowElement
 import org.w3c.dom.Node
 import kotlin.browser.document
 import kotlin.browser.window
@@ -55,6 +56,13 @@ fun repeatWithDelayUntil(check:()->Boolean, millisecondInterval:Int, run:()->Uni
 /** Creates a Div that is not attached to any parent HTMLElement yet. */
 fun Div(init:(HTMLDivElement.()->Unit)? = null): HTMLDivElement {
     val element: HTMLDivElement = document.createElement("div").asDynamic()
+    init?.let { element.init() }
+    return element
+}
+
+/** Creates a TR that is not attached to any parent HTMLElement yet. */
+fun Tr(init:(HTMLTableRowElement.()->Unit)? = null): HTMLTableRowElement {
+    val element: HTMLTableRowElement = document.createElement("tr").asDynamic()
     init?.let { element.init() }
     return element
 }

--- a/src/main/kotlin/net/yested/ext/jquery/effects.kt
+++ b/src/main/kotlin/net/yested/ext/jquery/effects.kt
@@ -5,12 +5,26 @@ import jquery.jq
 import net.yested.core.utils.setChild
 import org.w3c.dom.HTMLElement
 
-@native fun JQuery.fadeOut(duration:Int, callback:()->Unit) :Unit = noImpl;
-@native fun JQuery.fadeIn(duration:Int, callback:()->Unit) :Unit = noImpl;
-@native fun JQuery.slideUp(duration:Int, callback:()->Unit) :Unit = noImpl
-@native fun JQuery.slideDown(duration:Int, callback:()->Unit) :Unit = noImpl
-@native fun JQuery.show(callback:()->Unit) :Unit = noImpl;
-@native fun JQuery.hide(callback:()->Unit) :Unit = noImpl;
+@native fun JQuery.fadeOut(duration: Int, callback:()->Unit): JQuery = noImpl;
+@native fun JQuery.fadeIn(duration: Int, callback:()->Unit): JQuery = noImpl;
+@native fun JQuery.slideUp(duration: Int = 400, callback:(()->Unit)? = null): JQuery = noImpl
+@native fun JQuery.slideDown(duration: Int = 400, callback:(()->Unit)? = null): JQuery = noImpl
+@native fun JQuery.show(callback:()->Unit): JQuery = noImpl;
+@native fun JQuery.hide(callback:()->Unit): JQuery = noImpl;
+@native fun JQuery.children(selector: String): JQuery = noImpl
+
+fun JQuery.slideUpTableRow(duration:Int = 400, callback:(()->Unit)? = null): JQuery {
+    val tdElements = children("td")
+    tdElements.children("*").slideUp(duration)
+    var callbackDone = false
+    return tdElements.slideUp(duration) { if (!callbackDone) { callbackDone = true; callback?.invoke() } }
+}
+
+fun JQuery.slideDownTableRow(duration:Int = 400, callback:(()->Unit)? = null): JQuery {
+    val tdElements = children("td")
+    tdElements.children("*").slideDown()
+    return tdElements.slideDown(duration, callback)
+}
 
 private val DURATION = 200
 private val SLIDE_DURATION = DURATION * 2

--- a/src/main/kotlin/net/yested/ext/jquery/effects.kt
+++ b/src/main/kotlin/net/yested/ext/jquery/effects.kt
@@ -17,20 +17,18 @@ import kotlin.browser.window
 fun JQuery.slideUpTableRow(duration:Int = 400, callback:(()->Unit)? = null): JQuery {
     children("td").slideUp(duration).children("*").slideUp(duration)
     if (callback != null) {
-        window.setTimeout({
-            callback()
-        }, duration)
+        window.setTimeout(callback, duration)
     }
     return this
 }
 
 fun JQuery.slideDownTableRow(duration:Int = 400, callback:(()->Unit)? = null): JQuery {
-    children("td").slideDown(duration).children("*").slideDown(duration)
-    if (callback != null) {
-        window.setTimeout({
-            callback()
-        }, duration)
-    }
+    val jqTdElements = children("td")
+    jqTdElements.slideDown(duration).children("*").slideDown(duration)
+    window.setTimeout({
+        jqTdElements.attr("style", "").children("*").attr("style", "")
+        callback?.invoke()
+    }, duration)
     return this
 }
 

--- a/src/main/kotlin/net/yested/ext/jquery/effects.kt
+++ b/src/main/kotlin/net/yested/ext/jquery/effects.kt
@@ -4,6 +4,7 @@ import jquery.JQuery
 import jquery.jq
 import net.yested.core.utils.setChild
 import org.w3c.dom.HTMLElement
+import kotlin.browser.window
 
 @native fun JQuery.fadeOut(duration: Int, callback:()->Unit): JQuery = noImpl;
 @native fun JQuery.fadeIn(duration: Int, callback:()->Unit): JQuery = noImpl;
@@ -14,17 +15,23 @@ import org.w3c.dom.HTMLElement
 @native fun JQuery.children(selector: String): JQuery = noImpl
 
 fun JQuery.slideUpTableRow(duration:Int = 400, callback:(()->Unit)? = null): JQuery {
-    var callbackDone = false
-    return children("td").slideUp(duration).children("*").slideUp(duration) {
-        if (!callbackDone) { callbackDone = true; callback?.invoke() }
+    children("td").slideUp(duration).children("*").slideUp(duration)
+    if (callback != null) {
+        window.setTimeout({
+            callback()
+        }, duration)
     }
+    return this
 }
 
 fun JQuery.slideDownTableRow(duration:Int = 400, callback:(()->Unit)? = null): JQuery {
-    var callbackDone = false
-    return children("td").slideDown(duration).children("*").slideDown(duration) {
-        if (!callbackDone) { callbackDone = true; callback?.invoke() }
+    children("td").slideDown(duration).children("*").slideDown(duration)
+    if (callback != null) {
+        window.setTimeout({
+            callback()
+        }, duration)
     }
+    return this
 }
 
 private val DURATION = 200

--- a/src/main/kotlin/net/yested/ext/jquery/effects.kt
+++ b/src/main/kotlin/net/yested/ext/jquery/effects.kt
@@ -14,16 +14,17 @@ import org.w3c.dom.HTMLElement
 @native fun JQuery.children(selector: String): JQuery = noImpl
 
 fun JQuery.slideUpTableRow(duration:Int = 400, callback:(()->Unit)? = null): JQuery {
-    val tdElements = children("td")
-    tdElements.children("*").slideUp(duration)
     var callbackDone = false
-    return tdElements.slideUp(duration) { if (!callbackDone) { callbackDone = true; callback?.invoke() } }
+    return children("td").slideUp(duration).children("*").slideUp(duration) {
+        if (!callbackDone) { callbackDone = true; callback?.invoke() }
+    }
 }
 
 fun JQuery.slideDownTableRow(duration:Int = 400, callback:(()->Unit)? = null): JQuery {
-    val tdElements = children("td")
-    tdElements.children("*").slideDown()
-    return tdElements.slideDown(duration, callback)
+    var callbackDone = false
+    return children("td").slideDown(duration).children("*").slideDown(duration) {
+        if (!callbackDone) { callbackDone = true; callback?.invoke() }
+    }
 }
 
 private val DURATION = 200

--- a/src/test/kotlin/QUnit/qunit.kt
+++ b/src/test/kotlin/QUnit/qunit.kt
@@ -39,4 +39,5 @@ interface Assert {
     fun ok(actual: Boolean): Unit
     fun notOk(actual: Boolean): Unit
     fun throws(f: () -> Any, expectedException: Throwable, message: String = "should have thrown exception")
+    fun async(): ()->Unit
 }

--- a/src/test/kotlin/net/yested/core/html/HtmlBindTest.kt
+++ b/src/test/kotlin/net/yested/core/html/HtmlBindTest.kt
@@ -1,0 +1,92 @@
+package net.yested.core.html
+
+import net.yested.core.properties.*
+import net.yested.core.utils.Div
+import org.junit.Test
+import org.w3c.dom.HTMLCollection
+import org.w3c.dom.HTMLElement
+import org.w3c.dom.HTMLTableElement
+import spec.*
+import kotlin.dom.appendText
+
+/**
+ * A test for [tbody].
+ * @author Eric Pabst (epabst@gmail.com)
+ * Date: 9/29/16
+ * Time: 1:51 PM
+ */
+class HtmlBindTest {
+    @Test
+    fun tableShouldReflectData() {
+        val data: Property<List<Int>?> = listOf(1, 2, 3).toProperty()
+        var table: HTMLTableElement? = null
+        var nextId = 1
+        Div {
+            table = table {
+                thead {
+                    th {
+                        appendText("Items")
+                    }
+                }
+                tbody(data) { item ->
+                    tr { id = (nextId++).toString()
+                        td { appendText(item.toString()) }
+                    }
+                }
+            }
+        }
+        table!!.textContent.mustBe("Items123")
+
+        data.set(listOf(1, 2, 3))
+        table!!.textContent.mustBe("Items123")
+        getRowIdsAsString(table).mustBe("1,2,3")
+
+        data.set(listOf(2, 3, 1))
+        table!!.textContent.mustBe("Items231")
+        getRowIdsAsString(table).mustBe("2,3,4")
+
+        data.set(listOf(1, 2, 3))
+        table!!.textContent.mustBe("Items123")
+        getRowIdsAsString(table).mustBe("6,2,3")
+
+        data.set(listOf(1, 3, 2))
+        table!!.textContent.mustBe("Items132")
+        getRowIdsAsString(table).mustBe("5,6,2")
+
+        data.set(listOf(1, 2, 3, 4, 5, 6, 7, 8))
+        table!!.textContent.mustBe("Items12345678")
+        getRowIdsAsString(table).mustBe("5,2,7,8,9,10,11,12")
+
+        data.set(listOf(1, 2, 3, 8, 7, 4, 5, 6))
+        table!!.textContent.mustBe("Items12387456")
+        getRowIdsAsString(table).mustBe("5,2,7,13,14,8,9,10")
+
+        data.set(listOf(1, 2, 3, 4, 5, 6, 7, 8))
+        table!!.textContent.mustBe("Items12345678")
+        getRowIdsAsString(table).mustBe("5,2,7,8,9,10,15,16")
+
+        data.set(listOf(1, 2, 3, 4, 6, 7, 8))
+        table!!.textContent.mustBe("Items1234678")
+        getRowIdsAsString(table).mustBe("5,2,7,8,10,15,16")
+
+        data.set(listOf(1, 2, 3, 7, 8))
+        table!!.textContent.mustBe("Items12378")
+        getRowIdsAsString(table).mustBe("5,2,7,15,16")
+
+        data.set(listOf(8, 7, 3, 2, 1))
+        table!!.textContent.mustBe("Items87321")
+        getRowIdsAsString(table).mustBe("16,15,7,2,5")
+
+        data.set(listOf(10, 11, 12, 13))
+        table!!.textContent.mustBe("Items10111213")
+        getRowIdsAsString(table).mustBe("17,18,19,20")
+    }
+
+    private fun getRowIdsAsString(table: HTMLTableElement?): String {
+        return (table!!.lastChild!! as HTMLElement).children.toList().map { it.getAttribute("id")}.joinToString(",")
+    }
+}
+
+fun HTMLCollection.toList(): List<HTMLElement> {
+    return (0..(this.length - 1)).map { item(it)!! as HTMLElement }
+}

--- a/src/test/kotlin/net/yested/core/html/HtmlBindTest.kt
+++ b/src/test/kotlin/net/yested/core/html/HtmlBindTest.kt
@@ -1,5 +1,6 @@
 package net.yested.core.html
 
+import QUnit.Assert
 import net.yested.core.properties.*
 import net.yested.core.utils.Div
 import org.junit.Test
@@ -7,6 +8,7 @@ import org.w3c.dom.HTMLCollection
 import org.w3c.dom.HTMLElement
 import org.w3c.dom.HTMLTableElement
 import spec.*
+import kotlin.browser.window
 import kotlin.dom.appendText
 
 /**
@@ -16,8 +18,11 @@ import kotlin.dom.appendText
  * Time: 1:51 PM
  */
 class HtmlBindTest {
+    data class ListAssert(val list: List<Int>, val expectedText: String, val expectedIds: String)
+
     @Test
-    fun tableShouldReflectData() {
+    fun tableShouldReflectData(assert: Assert) {
+        val done = assert.async()
         val data: Property<List<Int>?> = listOf(1, 2, 3).toProperty()
         var table: HTMLTableElement? = null
         var nextId = 1
@@ -37,56 +42,47 @@ class HtmlBindTest {
         }
         table!!.textContent.mustBe("Items123")
 
-        data.set(listOf(1, 2, 3))
-        table!!.textContent.mustBe("Items123")
-        getRowIdsAsString(table).mustBe("1,2,3")
+        val listAssertSequence = listOf(
+                ListAssert(listOf(1, 2, 3), "Items123", "1,2,3"),
+                ListAssert(listOf(2, 3, 1), "Items231", "2,3,4"),
+                ListAssert(listOf(1, 2, 3), "Items123", "5,2,3"),
+                ListAssert(listOf(1, 3, 2), "Items132", "5,6,2"),
+                ListAssert(listOf(1, 2, 3, 4, 5, 6, 7, 8), "Items12345678", "5,7,6,8,9,10,11,12"),
+                ListAssert(listOf(1, 2, 3, 8, 7, 4, 5, 6), "Items12387456", "5,7,6,13,14,8,9,10"),
+                ListAssert(listOf(1, 2, 3, 4, 5, 6, 7, 8), "Items12345678", "5,7,6,8,9,10,16,15"),
+                ListAssert(listOf(1, 2, 3, 6, 7, 8, 4, 5), "Items12367845", "5,7,6,10,16,15,18,17"),
+                ListAssert(listOf(1, 2, 3, 6, 8, 4, 5), "Items1236845", "5,7,6,10,15,18,17"),
+                ListAssert(listOf(1, 2, 3, 4, 5), "Items12345", "5,7,6,18,17"),
+                ListAssert(listOf(5, 4, 3, 2, 1), "Items54321", "19,20,21,22,5"),
+                ListAssert(listOf(10, 11, 12, 13), "Items10111213", "23,24,25,26"),
+                ListAssert(listOf(12, 13, 14), "Items121314", "25,26,27"))
 
-        data.set(listOf(2, 3, 1))
-        table!!.textContent.mustBe("Items231")
-        getRowIdsAsString(table).mustBe("2,3,4")
+        val listAssertIterator = listAssertSequence.iterator()
+        validateListAsserts(listAssertIterator, table, data, done)
+    }
 
-        data.set(listOf(1, 2, 3))
-        table!!.textContent.mustBe("Items123")
-        getRowIdsAsString(table).mustBe("6,2,3")
-
-        data.set(listOf(1, 3, 2))
-        table!!.textContent.mustBe("Items132")
-        getRowIdsAsString(table).mustBe("5,6,2")
-
-        data.set(listOf(1, 2, 3, 4, 5, 6, 7, 8))
-        table!!.textContent.mustBe("Items12345678")
-        getRowIdsAsString(table).mustBe("5,2,7,8,9,10,11,12")
-
-        data.set(listOf(1, 2, 3, 8, 7, 4, 5, 6))
-        table!!.textContent.mustBe("Items12387456")
-        getRowIdsAsString(table).mustBe("5,2,7,13,14,8,9,10")
-
-        data.set(listOf(1, 2, 3, 4, 5, 6, 7, 8))
-        table!!.textContent.mustBe("Items12345678")
-        getRowIdsAsString(table).mustBe("5,2,7,8,9,10,15,16")
-
-        data.set(listOf(1, 2, 3, 4, 6, 7, 8))
-        table!!.textContent.mustBe("Items1234678")
-        getRowIdsAsString(table).mustBe("5,2,7,8,10,15,16")
-
-        data.set(listOf(1, 2, 3, 7, 8))
-        table!!.textContent.mustBe("Items12378")
-        getRowIdsAsString(table).mustBe("5,2,7,15,16")
-
-        data.set(listOf(8, 7, 3, 2, 1))
-        table!!.textContent.mustBe("Items87321")
-        getRowIdsAsString(table).mustBe("16,15,7,2,5")
-
-        data.set(listOf(10, 11, 12, 13))
-        table!!.textContent.mustBe("Items10111213")
-        getRowIdsAsString(table).mustBe("17,18,19,20")
+    private fun validateListAsserts(listAssertIterator: Iterator<ListAssert>, table: HTMLTableElement?, data: Property<List<Int>?>, done: () -> Unit) {
+        if (listAssertIterator.hasNext()) {
+            val listAssert = listAssertIterator.next()
+            // This callback will be called once tbody animation rendering is done
+            if (data.get() != listAssert.list) {
+                data.set(listAssert.list)
+                window.setTimeout({
+                    table!!.textContent.mustBe(listAssert.expectedText)
+                    getRowIdsAsString(table).mustBe(listAssert.expectedIds)
+                    validateListAsserts(listAssertIterator, table, data, done)
+                }, 500)
+            } else {
+                console.info("skipping since equal")
+                validateListAsserts(listAssertIterator, table, data, done)
+            }
+        } else {
+            console.info("all validateListAsserts are done")
+            done()
+        }
     }
 
     private fun getRowIdsAsString(table: HTMLTableElement?): String {
         return (table!!.lastChild!! as HTMLElement).children.toList().map { it.getAttribute("id")}.joinToString(",")
     }
-}
-
-fun HTMLCollection.toList(): List<HTMLElement> {
-    return (0..(this.length - 1)).map { item(it)!! as HTMLElement }
 }

--- a/src/test/kotlin/net/yested/core/utils/OperableListTest.kt
+++ b/src/test/kotlin/net/yested/core/utils/OperableListTest.kt
@@ -1,0 +1,109 @@
+package net.yested.core.utils
+
+import org.junit.Test
+import spec.mustBe
+
+/**
+ * A test for [OperableList].
+ * @author Eric Pabst (epabst@gmail.com)
+ * Date: 9/29/16
+ * Time: 1:51 PM
+ */
+class OperableListTest {
+
+    @Test
+    fun shouldDoNothingForTwoIdenticalLists() {
+        val originalList = InMemoryOperableList(mutableListOf(1, 2, 3))
+        originalList.reconcileToAndVerify(listOf(1, 2, 3))
+        originalList.modificationCount.mustBe(0)
+    }
+
+    @Test
+    fun shouldMoveSingleItemToEnd() {
+        val originalList = InMemoryOperableList(mutableListOf(1, 6, 2, 3, 4, 5))
+        originalList.reconcileToAndVerify(listOf(1, 2, 3, 4, 5, 6))
+        originalList.modificationCount.mustBe(1)
+    }
+
+    @Test
+    fun shouldMoveSingleItemToBeginning() {
+        val originalList = InMemoryOperableList(mutableListOf(2, 3, 4, 5, 6, 1))
+        originalList.reconcileToAndVerify(listOf(1, 2, 3, 4, 5, 6))
+        originalList.modificationCount.mustBe(1)
+    }
+
+    @Test
+    fun shouldMoveSingleItemEarlier() {
+        val originalList = InMemoryOperableList(mutableListOf(1, 2, 3, 5, 6, 4, 7))
+        originalList.reconcileToAndVerify(listOf(1, 2, 3, 4, 5, 6, 7))
+        originalList.modificationCount.mustBe(1)
+    }
+
+    @Test
+    fun shouldMoveTwoItemsEarlier() {
+        val originalList = InMemoryOperableList(mutableListOf(9, 6, 5, 4, 3, 8, 7, 2, 1))
+        originalList.reconcileToAndVerify(listOf(9, 8, 7, 6, 5, 4, 3, 2, 1))
+        originalList.modificationCount.mustBe(2)
+    }
+
+    @Test
+    fun shouldMoveTwoItemsEarlierSwappingTheirOrder() {
+        val originalList = InMemoryOperableList(mutableListOf(9, 6, 5, 4, 3, 7, 8, 2, 1))
+        originalList.reconcileToAndVerify(listOf(9, 8, 7, 6, 5, 4, 3, 2, 1))
+        originalList.modificationCount.mustBe(2)
+    }
+
+    @Test
+    fun shouldMoveTwoItemsLater() {
+        val originalList = InMemoryOperableList(mutableListOf(3, 2, 9, 8, 7, 6, 5, 4, 1))
+        originalList.reconcileToAndVerify(listOf(9, 8, 7, 6, 5, 4, 3, 2, 1))
+        originalList.modificationCount.mustBe(2)
+    }
+
+    @Test
+    fun shouldDeleteOneItem() {
+        val originalList = InMemoryOperableList(mutableListOf(9, 8, 7, 6, 5, 4, 3, 2, 1))
+        originalList.reconcileToAndVerify(listOf(9, 8, 7, 5, 4, 3, 2, 1))
+        originalList.modificationCount.mustBe(1)
+    }
+
+    @Test
+    fun shouldDeleteTwoItems() {
+        val originalList = InMemoryOperableList(mutableListOf(9, 8, 7, 6, 5, 4, 3, 2, 1))
+        originalList.reconcileToAndVerify(listOf(9, 8, 7, 5, 4, 2, 1))
+        originalList.modificationCount.mustBe(2)
+    }
+
+    @Test
+    fun shouldAddTwoItems() {
+        val originalList = InMemoryOperableList(mutableListOf(9, 7, 6, 5, 4, 3, 1))
+        originalList.reconcileToAndVerify(listOf(9, 8, 7, 6, 5, 4, 3, 2, 1))
+        originalList.modificationCount.mustBe(2)
+    }
+
+    @Test
+    fun shouldAddTwoItemsNearEnd_traversingFromRight() {
+        val originalList = InMemoryOperableList(mutableListOf(9, 8, 7, 6, 5, 1))
+        originalList.reconcileToAndVerify(listOf(8, 7, 6, 5, 9, 4, 3, 2, 1))
+        originalList.modificationCount.mustBe(4)
+    }
+
+    @Test
+    fun shouldHandleReversal() {
+        val originalList = InMemoryOperableList((1..10).reversed().toMutableList())
+        originalList.reconcileToAndVerify((1..10).toList())
+        originalList.modificationCount.mustBe(9)
+    }
+
+    @Test
+    fun shouldHandleTotalReplacement() {
+        val originalList = InMemoryOperableList((1..10).toMutableList())
+        originalList.reconcileToAndVerify((11..20).toList())
+        originalList.modificationCount.mustBe(20)
+    }
+}
+
+private fun <T> OperableList<T>.reconcileToAndVerify(desiredList: List<T>) {
+    reconcileTo(desiredList)
+    toList().mustBe(desiredList)
+}


### PR DESCRIPTION
The animation can be disabled by animate = false.
Preserving the HtmlTableRowElements fixes an update bug where each row is a Property
since the row was being re-rendered before upon any item being added or removed.