### PR TITLE
Update version to avoid confusion with existing yested.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.yested</groupId>
     <artifactId>Yested</artifactId>
-    <version>SNAPSHOT-1</version>
+    <version>1.0-alpha-SNAPSHOT</version>
     <properties>
         <kotlin.version>1.1.3</kotlin.version>
         <build.number>0.1.0.0</build.number>


### PR DESCRIPTION
https://github.com/jean79/yested has version 0.0.XXX.
This helps prepare yested_fw for release.