### PR TITLE
Improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <name>Yested Framework</name>
 
     <properties>
-        <kotlin.version>1.1.3</kotlin.version>
+        <kotlin.version>1.1.4</kotlin.version>
         <build.number>0.1.0.0</build.number>
         <skip.gpg>true</skip.gpg>
     </properties>

--- a/src/main/kotlin/net/yested/core/html/html.kt
+++ b/src/main/kotlin/net/yested/core/html/html.kt
@@ -28,7 +28,8 @@ fun HTMLElement.tbody(init:(HTMLTableSectionElement.()->Unit)? = null) = tag(thi
 fun HTMLElement.a(init:(HTMLAnchorElement.()->Unit)? = null) = tag(this, tagName = "a", init = init)
 fun HTMLElement.select(init:(HTMLSelectElement.()->Unit)? = null) = tag(this, tagName = "select", init = init)
 fun HTMLElement.ul(init:(HTMLUListElement.()->Unit)? = null) = tag(this, tagName = "ul", init = init)
-fun HTMLElement.li(init:(HTMLLIElement.()->Unit)? = null) = tag(this, tagName = "li", init = init)
+fun HTMLElement.li(before: HTMLElement? = null, init:(HTMLLIElement.()->Unit)? = null) =
+        tag(this, tagName = "li", before = before, init = init)
 fun HTMLElement.h1(init:(HTMLHeadingElement.()->Unit)? = null) = tag(this, tagName = "h1", init = init)
 fun HTMLElement.h2(init:(HTMLHeadingElement.()->Unit)? = null) = tag(this, tagName = "h2", init = init)
 fun HTMLElement.h3(init:(HTMLHeadingElement.()->Unit)? = null) = tag(this, tagName = "h3", init = init)

--- a/src/main/kotlin/net/yested/core/html/htmlbind.kt
+++ b/src/main/kotlin/net/yested/core/html/htmlbind.kt
@@ -26,6 +26,17 @@ fun HTMLInputElement.bind(property: Property<String>) {
     addEventListener("keyup", { updating = true; property.set(value); updating = false }, false)
 }
 
+fun HTMLInputElement.bindChecked(checked: Property<Boolean>) {
+    val element = this
+    var updating = false
+    checked.onNext {
+        if (!updating) {
+            element.checked = it
+        }
+    }
+    addEventListener("change", { updating = true; checked.set(element.checked); updating = false }, false)
+}
+
 fun <T> HTMLSelectElement.bindMultiselect(selected: Property<List<T>>, options: Property<List<T>>, render: HTMLElement.(T)->Unit) {
     val selectElement = this
     options.onNext {

--- a/src/main/kotlin/net/yested/core/html/htmlbind.kt
+++ b/src/main/kotlin/net/yested/core/html/htmlbind.kt
@@ -37,7 +37,7 @@ fun HTMLInputElement.bindChecked(checked: Property<Boolean>) {
     addEventListener("change", { updating = true; checked.set(element.checked); updating = false }, false)
 }
 
-fun <T> HTMLSelectElement.bindMultiselect(selected: Property<List<T>>, options: Property<List<T>>, render: HTMLElement.(T)->Unit) {
+fun <T> HTMLSelectElement.bindMultiselect(selected: Property<List<T>>, options: ReadOnlyProperty<List<T>>, render: HTMLElement.(T)->Unit) {
     val selectElement = this
     options.onNext {
         removeAllChildElements()
@@ -69,7 +69,7 @@ fun <T> HTMLSelectElement.bindMultiselect(selected: Property<List<T>>, options: 
     }, false)
 }
 
-fun <T> HTMLSelectElement.bind(selected: Property<T>, options: Property<List<T>>, render: HTMLElement.(T)->Unit) {
+fun <T> HTMLSelectElement.bind(selected: Property<T>, options: ReadOnlyProperty<List<T>>, render: HTMLElement.(T)->Unit) {
     val multipleSelected = selected.bind({ if (it == null) emptyList() else listOf(it) }, { it.firstOrNull() as T })
     bindMultiselect(multipleSelected, options, render)
 }

--- a/src/main/kotlin/net/yested/core/html/htmlbind.kt
+++ b/src/main/kotlin/net/yested/core/html/htmlbind.kt
@@ -90,8 +90,89 @@ fun HTMLInputElement.setReadOnly(property: ReadOnlyProperty<Boolean>) {
     property.onNext { readOnly = it }
 }
 
+fun HTMLCollection.toList(): List<HTMLElement> {
+    return (0..(this.length - 1)).map { item(it)!! as HTMLElement }
+}
+
+fun <C: HTMLElement,T> C.repeatLive(orderedData: ReadOnlyProperty<Iterable<T>?>, effect: BiDirectionEffect = NoEffect, itemInit: C.(T) -> Unit) {
+    return repeatLive(orderedData, effect, { index, item -> itemInit(item) })
+}
+
+fun <C: HTMLElement,T> C.repeatLive(orderedData: ReadOnlyProperty<Iterable<T>?>, effect: BiDirectionEffect = NoEffect, itemInit: C.(Int, T) -> Unit) {
+    val containerElement = this
+    val itemsWithoutDelays = mutableListOf<List<HTMLElement>>()
+    var operableList : DomOperableList<C,T>? = null
+    var elementAfter: HTMLElement? = null
+
+    orderedData.onNext { values ->
+        val operableListSnapshot = operableList
+        if (values == null) {
+            itemsWithoutDelays.flatten().forEach {
+                containerElement.removeChild(it)
+            }
+            itemsWithoutDelays.clear()
+            operableList = null
+        } else if (operableListSnapshot == null) {
+            itemsWithoutDelays.flatten().forEach {
+                containerElement.removeChild(it)
+            }
+            itemsWithoutDelays.clear()
+            val domOperableList = DomOperableList(values.toMutableList(), itemsWithoutDelays, containerElement, effect, elementAfter, itemInit)
+            values.forEachIndexed { index, item ->
+                domOperableList.addItemToContainer(containerElement, index, item, itemsWithoutDelays, elementAfter)
+            }
+            operableList = domOperableList
+        } else {
+            operableListSnapshot.reconcileTo(values.toList())
+        }
+    }
+    elementAfter = span() // create a <span/> to clearly indicate where to insert new elements.
+    operableList?.elementAfter = elementAfter
+}
+
+internal class DomOperableList<C : HTMLElement,T>(
+        initialData: MutableList<T>,
+        val itemsWithoutDelays: MutableList<List<HTMLElement>>,
+        val container: C,
+        val effect: BiDirectionEffect,
+        var elementAfter: HTMLElement? = null,
+        val itemInit: C.(Int, T) -> Unit) : InMemoryOperableList<T>(initialData) {
+    override fun add(index: Int, item: T) {
+        addItemToContainer(container, index, item, itemsWithoutDelays, elementAfter).forEach { effect.applyIn(it) }
+        super.add(index, item)
+    }
+
+    override fun removeAt(index: Int): T {
+        val elementsForIndex = itemsWithoutDelays.removeAt(index)
+        elementsForIndex.forEach {
+            effect.applyOut(it) {
+                container.removeChild(it)
+            }
+        }
+        return super.removeAt(index)
+    }
+
+    override fun move(fromIndex: Int, toIndex: Int) {
+        val item = removeAt(fromIndex)
+        add(toIndex, item)
+    }
+
+    fun addItemToContainer(container: C, index: Int, item: T, itemsWithoutDelays: MutableList<List<HTMLElement>>, elementAfter: HTMLElement?): List<HTMLElement> {
+        val nextElement = if (index < itemsWithoutDelays.size) itemsWithoutDelays.get(index).firstOrNull() else elementAfter
+        val childrenBefore = container.children.toList()
+        container.itemInit(index, item)
+        val childrenLater = container.children.toList()
+        val newChildren = childrenLater.filterNot { childrenBefore.contains(it) }
+        if (nextElement != null) {
+            newChildren.forEach { container.insertBefore(it, nextElement) }
+        }
+        itemsWithoutDelays.add(index, newChildren)
+        return newChildren
+    }
+}
+
 /**
- * Bind table content to a Property<Iterable<T>>.  The index and value are provided to tbodyItemInit.
+ * Bind table content to a Property<Iterable<T>>.  The index and value are provided to itemInit.
  * Example:<pre>
  *   table {
  *       thead {
@@ -108,35 +189,12 @@ fun HTMLInputElement.setReadOnly(property: ReadOnlyProperty<Boolean>) {
  * </pre>
  */
 fun <T> HTMLTableElement.tbody(orderedData: ReadOnlyProperty<Iterable<T>?>, effect: BiDirectionEffect = NoEffect,
-                               tbodyItemInit: TableItemContext.(Int, T) -> Unit) {
-    var tbodyOperableList : TBodyOperableList<T>? = null
-
-    orderedData.onNext { values ->
-        val operableListSnapshot = tbodyOperableList
-        if (values == null) {
-            removeChildByName("tbody")
-            tbodyOperableList = null
-        } else if (operableListSnapshot == null) {
-            val tbody = setTBodyContentsImmediately(values, tbodyItemInit)
-            tbodyOperableList = TBodyOperableList(values.toMutableList(), tbody, effect, tbodyItemInit)
-        } else {
-            operableListSnapshot.reconcileTo(values.toList())
-        }
-    }
-}
-
-private fun <T> HTMLTableElement.setTBodyContentsImmediately(values: Iterable<T>?, tbodyItemInit: TableItemContext.(Int, T) -> Unit): HTMLTableSectionElement {
-    removeChildByName("tbody")
-    return tbody {
-        val tbody = this
-        values?.forEachIndexed { index, item ->
-            TableItemContext({ rowInit -> tbody.tr(init = rowInit) }).tbodyItemInit(index, item)
-        }
-    }
+                               itemInit: HTMLTableSectionElement.(Int, T) -> Unit) {
+    tbody { repeatLive(orderedData, effect, itemInit) }
 }
 
 /**
- * Bind table content to a Property<Iterable<T>>.  The value is provided to tbodyItemInit.
+ * Bind table content to a Property<Iterable<T>>.  The value is provided to itemInit.
  * Example:<pre>
  *   table {
  *       thead {
@@ -153,48 +211,6 @@ private fun <T> HTMLTableElement.setTBodyContentsImmediately(values: Iterable<T>
  * </pre>
  */
 fun <T> HTMLTableElement.tbody(orderedData: ReadOnlyProperty<Iterable<T>?>, effect: BiDirectionEffect = NoEffect,
-                               tbodyItemInit: TableItemContext.(T) -> Unit) {
-    return tbody(orderedData, effect, { index, item -> tbodyItemInit(item) })
-}
-
-class TableItemContext(private val rowFactory: ((HTMLTableRowElement.()->Unit)?)->HTMLTableRowElement) {
-    fun tr(init:(HTMLTableRowElement.()->Unit)? = null): HTMLTableRowElement {
-        return rowFactory.invoke(init)
-    }
-}
-
-fun HTMLCollection.toList(): List<HTMLElement> {
-    return (0..(this.length - 1)).map { item(it)!! as HTMLElement }
-}
-
-class TBodyOperableList<T>(initialData: MutableList<T>, val tbodyElement: HTMLTableSectionElement,
-                           val effect: BiDirectionEffect,
-                           val tbodyItemInit: TableItemContext.(Int, T)->Unit) : InMemoryOperableList<T>(initialData) {
-    private val rowsWithoutDelays = tbodyElement.rows.toList().toMutableList()
-
-    override fun add(index: Int, item: T) {
-        val nextRow = if (index < rowsWithoutDelays.size) rowsWithoutDelays.get(index) else null
-        TableItemContext({ rowInit ->
-            val newRow = tbodyElement.tr(before = nextRow, init = rowInit)
-            effect.applyIn(newRow)
-            rowsWithoutDelays.add(index, newRow)
-            newRow
-        }).tbodyItemInit(index, item)
-        super.add(index, item)
-    }
-
-    override fun removeAt(index: Int): T {
-        val row = rowsWithoutDelays.removeAt(index)
-        effect.applyOut(row) {
-            tbodyElement.removeChild(row)
-        }
-        return super.removeAt(index)
-    }
-
-    override fun move(fromIndex: Int, toIndex: Int) {
-        val item = removeAt(fromIndex)
-        add(toIndex, item)
-//        super.move(fromIndex, toIndex)
-//        (tbodyElement.parentElement as HTMLTableElement?)?.setTBodyContentsImmediately(toList(), tbodyItemInit)
-    }
+                               itemInit: HTMLTableSectionElement.(T) -> Unit): HTMLTableSectionElement {
+    return tbody { repeatLive(orderedData, effect, itemInit) }
 }

--- a/src/main/kotlin/net/yested/core/html/htmlbind.kt
+++ b/src/main/kotlin/net/yested/core/html/htmlbind.kt
@@ -3,6 +3,7 @@ package net.yested.core.html
 import net.yested.core.properties.Property
 import net.yested.core.properties.ReadOnlyProperty
 import net.yested.core.properties.bind
+import net.yested.core.properties.zip
 import net.yested.core.utils.*
 import org.w3c.dom.*
 import kotlin.browser.document
@@ -49,10 +50,12 @@ fun <T> HTMLSelectElement.bindMultiselect(selected: Property<List<T>>, options: 
         }
     }
     var updating = false
-    selected.onNext { selectedList ->
+    selected.zip(options).onNext { (selectedList, options) ->
         if (!updating) {
-            options.get().forEachIndexed { index, option ->
-                (selectElement.options.get(index) as HTMLOptionElement).selected = selectedList.contains(option)
+            options.forEachIndexed { index, option ->
+                if (index < selectElement.options.length) {
+                    (selectElement.options.get(index) as HTMLOptionElement).selected = selectedList.contains(option)
+                }
             }
         }
     }

--- a/src/main/kotlin/net/yested/core/html/htmlbind.kt
+++ b/src/main/kotlin/net/yested/core/html/htmlbind.kt
@@ -74,10 +74,13 @@ fun <T> HTMLSelectElement.bind(selected: Property<T>, options: Property<List<T>>
     bindMultiselect(multipleSelected, options, render)
 }
 
-
 fun HTMLElement.setClassPresence(className: String, present: ReadOnlyProperty<Boolean>) {
-    present.onNext {
-        if (it) addClass(className) else removeClass(className)
+    setClassPresence(className, present, true)
+}
+
+fun <T> HTMLElement.setClassPresence(className: String, property: ReadOnlyProperty<T>, presentValue: T) {
+    property.onNext {
+        if (it == presentValue) addClass(className) else removeClass(className)
     }
 }
 

--- a/src/main/kotlin/net/yested/core/html/inputs.kt
+++ b/src/main/kotlin/net/yested/core/html/inputs.kt
@@ -1,0 +1,36 @@
+package net.yested.core.html
+
+import net.yested.core.properties.Property
+import org.w3c.dom.HTMLElement
+import org.w3c.dom.HTMLInputElement
+import kotlin.browser.document
+
+/**
+ * HTML input.
+ * @author Eric Pabst (epabst@gmail.com)
+ * Date: 8/4/17
+ * Time: 10:35 PM
+ */
+
+
+/**
+ * A checkbox.
+ * @see [setDisabled]
+ * @see [setReadOnly]
+ */
+fun HTMLElement.checkbox(
+        checked: Property<Boolean>,
+        name: String? = null,
+        value: String? = null,
+        id: String? = null,
+        init: (HTMLInputElement.() -> Unit)? = null): HTMLInputElement {
+    val element = document.createElement("input") as HTMLInputElement
+    id?.let { element.id = id }
+    element.type = "checkbox"
+    element.name = name ?: ""
+    element.value = value ?: ""
+    element.bindChecked(checked)
+    if (init != null) element.init()
+    this.appendChild(element)
+    return element
+}

--- a/src/main/kotlin/net/yested/core/properties/properties.kt
+++ b/src/main/kotlin/net/yested/core/properties/properties.kt
@@ -416,7 +416,7 @@ fun <T> ReadOnlyProperty<Iterable<T>?>.sortedWith(sortSpecification: ReadOnlyPro
     return sortedWith(sortSpecification.map { it?.fullComparator })
 }
 
-fun <T> ReadOnlyProperty<Iterable<T>?>.sortedWith(comparator: ReadOnlyProperty<Comparator<T>?>): ReadOnlyProperty<Iterable<T>?> {
+fun <T> ReadOnlyProperty<Iterable<T>?>.sortedWith(comparator: ReadOnlyProperty<Comparator<in T>?>): ReadOnlyProperty<Iterable<T>?> {
     return mapWith(comparator) { toSort, comparator ->
         if (comparator == null || toSort == null) {
             toSort

--- a/src/main/kotlin/net/yested/core/properties/properties.kt
+++ b/src/main/kotlin/net/yested/core/properties/properties.kt
@@ -19,6 +19,21 @@ interface ReadOnlyProperty<out T> {
     fun onNext(handler: (T)->Unit):Disposable
 }
 
+private val nullProperty: ReadOnlyProperty<Any?> = object : ReadOnlyProperty<Any?> {
+    val emptyDisposable: Disposable = object : Disposable {
+        override fun dispose() {}
+    }
+
+    override fun get(): Any? = null
+
+    override fun onNext(handler: (Any?) -> Unit): Disposable {
+        handler(null)
+        return emptyDisposable
+    }
+}
+@Suppress("UNCHECKED_CAST")
+fun <T> nullProperty(): ReadOnlyProperty<T?> = nullProperty as ReadOnlyProperty<T>
+
 /** A mutable Property that can be subscribed to.  The T value should be immutable or else its changes won't be detected. */
 class Property<T>(initialValue: T): ReadOnlyProperty<T> {
 
@@ -97,6 +112,18 @@ fun <IN, OUT> ReadOnlyProperty<IN>.flatMap(transform: (IN)->ReadOnlyProperty<OUT
         disposable = transform(value).onNext { result.set(it) }
     }
     return result
+}
+
+fun <IN, OUT> ReadOnlyProperty<IN>.flatMapOrNull(transform: (IN)->ReadOnlyProperty<OUT?>?): ReadOnlyProperty<OUT?> {
+    return flatMap<IN,OUT?> { transform(it) ?: nullProperty() }
+}
+
+fun <IN, OUT> ReadOnlyProperty<IN?>.flatMapIfNotNull(transform: (IN)->ReadOnlyProperty<OUT?>?): ReadOnlyProperty<OUT?> {
+    return flatMapOrNull<IN?,OUT?> { it?.let(transform) }
+}
+
+fun <IN, OUT> ReadOnlyProperty<IN?>.mapIfNotNull(default: OUT? = null, transform: (IN)->OUT?): ReadOnlyProperty<OUT?> {
+    return map { it?.let { transform(it) } ?: default }
 }
 
 /**

--- a/src/main/kotlin/net/yested/core/properties/properties.kt
+++ b/src/main/kotlin/net/yested/core/properties/properties.kt
@@ -383,6 +383,7 @@ fun <T> Property<List<T>>.modifyList(operation: (ArrayList<T>) -> Unit) {
 fun <T> Property<List<T>>.clear() { modifyList { it.clear() } }
 fun <T> Property<List<T>>.removeAt(index: Int) { modifyList { it.removeAt(index) } }
 fun <T> Property<List<T>>.add(item: T) { modifyList { it.add(item) } }
+fun <T> Property<List<T>>.remove(item: T) { modifyList { it.remove(item) } }
 
 fun <T> ReadOnlyProperty<Iterable<T>?>.sortedWith(sortSpecification: ReadOnlyProperty<SortSpecification<T>?>): ReadOnlyProperty<Iterable<T>?> {
     return sortedWith(sortSpecification.map { it?.fullComparator })

--- a/src/main/kotlin/net/yested/core/properties/validators.kt
+++ b/src/main/kotlin/net/yested/core/properties/validators.kt
@@ -6,14 +6,15 @@ class ValidationStatus(
     override fun toString() = if (success) "OK" else "Error: $errorMessage"
 }
 
-fun <T> ReadOnlyProperty<T>.validate(errorMessage: String, condition: (T) -> Boolean) =
-        this.map {
-            if (condition(it)) {
-                ValidationStatus(success = true, errorMessage = "")
-            } else {
-                ValidationStatus(success = false, errorMessage = errorMessage)
-            }
+fun <T> ReadOnlyProperty<T>.validate(errorMessage: String, condition: (T) -> Boolean): ReadOnlyProperty<ValidationStatus> {
+    return this.map {
+        if (condition(it)) {
+            ValidationStatus(success = true, errorMessage = "")
+        } else {
+            ValidationStatus(success = false, errorMessage = errorMessage)
         }
+    }
+}
 
 fun ReadOnlyProperty<ValidationStatus>.isValid(): Boolean {
     return get().success

--- a/src/main/kotlin/net/yested/core/utils/functional.kt
+++ b/src/main/kotlin/net/yested/core/utils/functional.kt
@@ -1,6 +1,6 @@
 package net.yested.core.utils
 
-import net.yested.core.properties.Property
+import net.yested.core.properties.ReadOnlyProperty
 import kotlin.comparisons.compareBy
 import kotlin.comparisons.compareValues
 
@@ -14,12 +14,12 @@ fun <T, V : Comparable<V>> compareByValue(get: (T) -> V?): (T, T) -> Int {
 }
 
 /** Compare two Property values.  This is especially useful when using a grid of Iterable<Property<T>>. */
-fun <T, V : Comparable<V>> compareByPropertyValue(get: (T) -> V?): (Property<T>, Property<T>) -> Int {
-    return compareByValue<Property<T>,V> { get(it.get()) }
+fun <T, V : Comparable<V>> compareByPropertyValue(get: (T) -> V?): (ReadOnlyProperty<T>, ReadOnlyProperty<T>) -> Int {
+    return compareByValue<ReadOnlyProperty<T>,V> { get(it.get()) }
 }
 
 /** Compare two Property values.  This is especially useful when using a grid of Iterable<Property<T>>. */
-fun <T> compareByProperty(get: (T) -> Comparable<*>?): Comparator<Property<T>> {
+fun <T> compareByProperty(get: (T) -> Comparable<*>?): Comparator<ReadOnlyProperty<T>> {
     return compareBy { get(it.get()) }
 }
 

--- a/src/main/kotlin/net/yested/core/utils/sortControl.kt
+++ b/src/main/kotlin/net/yested/core/utils/sortControl.kt
@@ -29,8 +29,10 @@ import kotlin.comparisons.*
  * Time: 4:51 PM
  */
 fun <T> HTMLTableCellElement.sortControl(currentSort: Property<SortSpecification<T>?>,
-                                               comparator: Comparator<T>, sortAscending: Boolean = true,
-                                               sortNow: Boolean = false, init: HTMLElement.() -> Unit): Property<Boolean?> {
+                                         comparator: Comparator<T>,
+                                         sortAscending: Boolean = true,
+                                         sortNow: Boolean = false,
+                                         init: HTMLElement.() -> Unit): Property<Boolean?> {
     val sortSpecification = SortSpecification(comparator, sortAscending)
     val sortControlProperty = currentSort.mapAsDefault {
         if (it == null || it.sortableId != sortSpecification.sortableId) null else it.ascending
@@ -51,10 +53,10 @@ fun <T> HTMLTableCellElement.sortControl(currentSort: Property<SortSpecification
     return sortControlProperty
 }
 
-class SortSpecification<T> private constructor (val comparator: Comparator<T>, val ascending: Boolean, val sortableId: Int) {
+class SortSpecification<in T> private constructor (val comparator: Comparator<in T>, val ascending: Boolean, val sortableId: Int) {
     constructor(comparator: Comparator<T>, ascending: Boolean = true) : this(comparator, ascending, nextSortableId++)
 
-    val fullComparator: Comparator<T>? = if (ascending) comparator else comparator.reversed()
+    val fullComparator: Comparator<in T>? = if (ascending) comparator else comparator.reversed()
     val reverse: SortSpecification<T> by lazy { SortSpecification(comparator, !ascending, sortableId) }
 
     private companion object {

--- a/src/main/kotlin/net/yested/ext/bootstrap3/formext.kt
+++ b/src/main/kotlin/net/yested/ext/bootstrap3/formext.kt
@@ -2,6 +2,7 @@ package net.yested.ext.bootstrap3
 
 import net.yested.core.html.p
 import net.yested.core.properties.ReadOnlyProperty
+import net.yested.core.properties.toProperty
 import org.w3c.dom.*
 import kotlin.dom.appendText
 
@@ -26,7 +27,7 @@ class BtsFormContext(
 
     fun btsFormItem(
             labelId: String = "${++labelIdSequence}",
-            state: ReadOnlyProperty<State>,
+            state: ReadOnlyProperty<State> = State.Default.toProperty(),
             init: BtsFormItemContext.() -> Unit) {
 
         element.formGroup(state = state) {
@@ -43,7 +44,7 @@ class BtsFormContext(
 
     fun btsFormItemSimple(
             labelId: String = "${++labelIdSequence}",
-            state: ReadOnlyProperty<State>,
+            state: ReadOnlyProperty<State> = State.Default.toProperty(),
             label: String = "",
             init: HTMLDivElement.(labelId: String) -> Unit) {
 

--- a/src/main/kotlin/net/yested/ext/bootstrap3/grid.kt
+++ b/src/main/kotlin/net/yested/ext/bootstrap3/grid.kt
@@ -187,7 +187,7 @@ private fun <T> HTMLElement.gridTable(columns: Array<Column<T>>, data: ReadOnlyP
         val comparator: Comparator<T>? = column.comparator
     }
 
-    val columnSort: Property<ColumnSort<T>?> = sortColumn.mapAsDefault { it?.let { ColumnSort(it, it.sortAscending!!) } }
+    val columnSort: ReadOnlyProperty<ColumnSort<T>?> = sortColumn.mapIfNotNull { ColumnSort(it, it.sortAscending!!) }
     val sortSpecification: Property<SortSpecification<T>?> = columnSort.mapAsDefault {
         if (it != null && it.comparator != null) SortSpecification(it.comparator, it.ascending) else null
     }

--- a/src/main/kotlin/net/yested/ext/bootstrap3/grid.kt
+++ b/src/main/kotlin/net/yested/ext/bootstrap3/grid.kt
@@ -202,7 +202,7 @@ private fun <T> HTMLElement.gridTable(columns: Array<Column<T>>, data: ReadOnlyP
                         if (column.comparator == null) {
                             (column.label)()
                         } else {
-                            sortControlWithArrow<T>(sortSpecification, column.comparator, column.sortAscending!!) {
+                            sortControlWithArrow(sortSpecification, column.comparator, column.sortAscending!!) {
                                 (column.label)()
                             }
                         }
@@ -224,8 +224,10 @@ private fun <T> HTMLElement.gridTable(columns: Array<Column<T>>, data: ReadOnlyP
 }
 
 fun <T> HTMLTableCellElement.sortControlWithArrow(currentSort: Property<SortSpecification<T>?>,
-                                                        comparator: Comparator<T>, sortAscending: Boolean = true,
-                                                        sortNow: Boolean = false, init: HTMLElement.() -> Unit): Property<Boolean?> {
+                                                  comparator: Comparator<T>,
+                                                  sortAscending: Boolean = true,
+                                                  sortNow: Boolean = false,
+                                                  init: HTMLElement.() -> Unit): Property<Boolean?> {
     val ascendingProperty = sortControl(currentSort, comparator, sortAscending, sortNow, init)
     span {
         val icon = ascendingProperty.map { ascending ->

--- a/src/main/kotlin/net/yested/ext/bootstrap3/inputs.kt
+++ b/src/main/kotlin/net/yested/ext/bootstrap3/inputs.kt
@@ -46,7 +46,7 @@ fun <T> HTMLElement.selectInput(
         disabled: ReadOnlyProperty<Boolean> = false.toProperty(),
         multiple: Boolean,
         size: Size = Size.Default,
-        render: HTMLElement.(T)->Unit) {
+        render: HTMLElement.(T)->Unit): HTMLSelectElement {
 
     val element = document.createElement("select") as HTMLSelectElement
     element.className = "form-control input-${size.code}"
@@ -54,13 +54,14 @@ fun <T> HTMLElement.selectInput(
     element.bindMultiselect(selected, options, render)
     element.setDisabled(disabled)
     this.appendChild(element)
+    return element
 }
 
 fun <T> HTMLElement.singleSelectInput(
         selected: Property<T>,
-        options: Property<List<T>>,
+        options: ReadOnlyProperty<List<T>>,
         disabled: ReadOnlyProperty<Boolean> = false.toProperty(),
-        render: HTMLElement.(T)->Unit) {
+        render: HTMLElement.(T)->Unit): HTMLSelectElement {
 
     val element = document.createElement("select") as HTMLSelectElement
     element.className = "form-control input-${Size.Default.code}"
@@ -68,6 +69,7 @@ fun <T> HTMLElement.singleSelectInput(
     element.bind(selected, options, render)
     element.setDisabled(disabled)
     this.appendChild(element)
+    return element
 }
 
 fun HTMLElement.intInput(value: Property<Int?>,

--- a/src/main/kotlin/net/yested/ext/bootstrap3/modal.kt
+++ b/src/main/kotlin/net/yested/ext/bootstrap3/modal.kt
@@ -8,7 +8,9 @@ import net.yested.core.utils.Div
 import net.yested.ext.jquery.yestedJQuery
 import org.w3c.dom.HTMLDivElement
 import org.w3c.dom.HTMLHeadingElement
+import kotlin.dom.addClass
 import kotlin.dom.appendText
+import kotlin.dom.removeClass
 
 interface DialogControl {
     fun showDialog()
@@ -25,10 +27,12 @@ class DialogContext internal constructor(val header: HTMLHeadingElement, val bod
     }
 
     fun body(init:HTMLDivElement.()->Unit) {
+        body.removeClass("hidden")
         body.init()
     }
 
     fun footer(init:HTMLDivElement.()->Unit) {
+        footer.removeClass("hidden")
         footer.init()
     }
 
@@ -75,11 +79,11 @@ fun prepareDialog(size: DialogSize = DialogSize.Default, init:DialogContext.(dia
 
                 }
                 div {
-                    className = "modal-body"
+                    addClass("modal-body hidden") // DialogContext.body will unhide this
                     body = this
                 }
                 div {
-                    className = "modal-footer"
+                    addClass("modal-footer hidden") // DialogContext.footer will unhide this
                     footer = this
                 }
             }

--- a/src/main/kotlin/net/yested/ext/bootstrap3/navs.kt
+++ b/src/main/kotlin/net/yested/ext/bootstrap3/navs.kt
@@ -8,8 +8,6 @@ import net.yested.core.properties.toProperty
 import org.w3c.dom.HTMLElement
 import org.w3c.dom.HTMLLIElement
 import org.w3c.dom.HTMLUListElement
-import kotlin.dom.addClass
-import kotlin.dom.removeClass
 
 class NavContext(val el: HTMLUListElement) {
 

--- a/src/main/kotlin/net/yested/ext/jquery/YestedJQuery.kt
+++ b/src/main/kotlin/net/yested/ext/jquery/YestedJQuery.kt
@@ -31,8 +31,6 @@ external interface YestedJQuery {
     //fun post(url:String, data:Any?, handler:()->Unit, type:String = "json") : Unit = definedExternally
     //fun ajax(url:String, type:String, contentType:String, dataType:String, data:Any, success:()->Unit) : Unit = definedExternally
     fun <RESULT> ajax(request: AjaxRequest<RESULT>) : Unit
-    /** Requires pickadate.js */
-    fun pickadate(param: Any): Unit
 }
 
 external interface JQueryWindow {

--- a/src/main/kotlin/net/yested/ext/jquery/router.kt
+++ b/src/main/kotlin/net/yested/ext/jquery/router.kt
@@ -15,7 +15,8 @@ private val windowLocationHash: Property<String> = window.location.bindToHash()
 
 /** A Property for window.location.hash as a split array.  It is bound to [hashProperty]. */
 val Location.splitHashProperty: Property<Array<String>> get() = splitWindowLocationHash
-private val splitWindowLocationHash: Property<Array<String>> = windowLocationHash.bind({ it.split("_").toTypedArray() }, { it.joinToString("_") })
+// The "_" is deprecated in favor of "/".
+private val splitWindowLocationHash: Property<Array<String>> = windowLocationHash.bind({ it.split("/", "_").toTypedArray() }, { it.joinToString("/") })
 
 private fun Location.bindToHash(): Property<String> {
     val property: Property<String> = Property(hash)

--- a/src/main/kotlin/net/yested/ext/pickadate/dateinput.kt
+++ b/src/main/kotlin/net/yested/ext/pickadate/dateinput.kt
@@ -19,8 +19,16 @@ import kotlin.browser.document
  * Time: 6:44 AM
  */
 
-/** A dateInput. */
-fun HTMLElement.dateInput(data: Property<Moment?>, placeholder: String? = null, formatter: FormatStringBuilder.()-> FormatString) {
+/**
+ * A dateInput.
+ * @param clearLabel the label to put on the "Clear" button on the pick-a-date dialog.
+ */
+fun HTMLElement.dateInput(data: Property<Moment?>,
+                          placeholder: String? = null,
+                          clearLabel: String = "Clear",
+                          formatter: FormatStringBuilder.()-> FormatString,
+                          init: (HTMLInputElement.() -> Unit)? = null) {
+
     val formatString = FormatStringBuilder().formatter().toString()
 
     val text = data.asText(formatString)
@@ -32,15 +40,20 @@ fun HTMLElement.dateInput(data: Property<Moment?>, placeholder: String? = null, 
     element.type = "text"
     if (placeholder != null) { element.placeholder = placeholder }
     element.bind(text)
+    if (init != null) element.init()
     this.appendChild(element)
+
+    val options = PickADateOptions(
+            format= formatString.toLowerCase(),
+            selectMonths = true,
+            selectYears = true,
+            clear = clearLabel,
+            onSet = { context -> data.set(context.select?.let { Moment.parseMillisecondsSinceUnixEpoch(it) }) }
+    )
+
     whenAddedToDom {
         text.onNext { setAttribute("data-value", it) }
 
-        yestedJQuery(element).pickadate(PickADateOptions(formatString.toLowerCase(), selectMonths = true, selectYears = true,
-                onSet = { context: DateContext ->
-                    if (context.select != undefined)
-                        data.set(context.select?.let { Moment.parseMillisecondsSinceUnixEpoch(it) })
-                })
-        )
+        yestedJQuery(element).pickadate(options)
     }
 }

--- a/src/main/kotlin/net/yested/ext/pickadate/pickadate.kt
+++ b/src/main/kotlin/net/yested/ext/pickadate/pickadate.kt
@@ -12,15 +12,12 @@ class DateContext {
     var select: Long? = null
 }
 
-class PickADateOptions(var format: String, var selectMonths: Boolean = false, var selectYears: Boolean = false,
+class PickADateOptions(var format: String,
+                       var selectMonths: Boolean = false,
+                       var selectYears: Boolean = false,
+                       var clear: String = "Clear",
                        var onSet: (DateContext) -> Unit)
 
 fun YestedJQuery.pickadate(options: PickADateOptions) {
-    val param: dynamic = object {}
-    param.format = options.format
-    param.selectMonths = options.selectMonths
-    param.selectYears = options.selectYears
-    param.onSet = options.onSet
-    pickadate(param as Any)
+    this.asDynamic().pickadate(options)
 }
-

--- a/src/test/kotlin/demo.kt
+++ b/src/test/kotlin/demo.kt
@@ -94,11 +94,16 @@ fun main(args: Array<String>) {
             p {
                 btsForm(format = FormFormat.Horizontal) {
                     formGroup(state = validation) {
-                        btsLabel(htmlFor = "ii", width = Col.Width.Lg(4)) {
+                        btsLabel(htmlFor = "ii", width = Col.Width.Sm(6)) {
                             appendText("Label")
-                        }
-                        col(Col.Width.Lg(4)) {
                             textInput(id = "ii", value = p)
+                        }
+                        val checked = false.toProperty()
+                        btsLabel(width = Col.Width.Sm(6)) {
+                            div { className = "checkbox"
+                                checkbox(checked, name = "vehicle", value = "bicycle")
+                                span { checked.onNext { textContent = if (it) "Checked" else "Unchecked" } }
+                            }
                         }
                     }
                     btsButton { appendText("Submit") }

--- a/src/test/kotlin/demo.kt
+++ b/src/test/kotlin/demo.kt
@@ -3,6 +3,8 @@ import net.yested.core.properties.*
 import net.yested.core.utils.SortSpecification
 import net.yested.core.utils.with
 import net.yested.ext.bootstrap3.*
+import net.yested.ext.jquery.Slide
+import net.yested.ext.jquery.SlideTableRow
 import org.w3c.dom.HTMLElement
 import kotlin.browser.document
 import kotlin.comparisons.compareBy
@@ -268,6 +270,7 @@ fun main(args: Array<String>) {
                 }
             }
             val currentSort = Property<SortSpecification<String>?>(null)
+            val urlList = listOf("http://www.seznam.cz", "http://www.google.com", "http://www.yahoo.com").toProperty().sortedWith(currentSort)
             table {
                 className = "table table-striped table-hover table-condensed"
                 thead {
@@ -276,13 +279,22 @@ fun main(args: Array<String>) {
                         th { sortControlWithArrow(currentSort, compareBy<String> { it.length }) { appendText("URL Length") } }
                     }
                 }
-                tbody(listOf("http://www.seznam.cz", "http://www.google.com", "http://www.yahoo.com").toProperty().sortedWith(currentSort)) { index, value ->
+                tbody(urlList, effect = SlideTableRow()) { index, value ->
                     tr { className = if (index % 2 == 0) "even" else "odd"
                         td { appendText(value) }
                         td { appendText(value.length.toString()) }
                     }
                 }
             }
+            ul {
+                repeatLive(urlList, effect = Slide()) { value -> li { appendText(value) } }
+                li { appendText("None of the above") }
+            }
+            br()
+            br()
+            br()
+            br()
+            br()
         }
     }
 }

--- a/src/test/kotlin/net/yested/core/html/HtmlBindTest.kt
+++ b/src/test/kotlin/net/yested/core/html/HtmlBindTest.kt
@@ -7,19 +7,38 @@ import net.yested.core.utils.NoEffect
 import net.yested.ext.bootstrap3.Collapse
 import org.junit.Test
 import org.w3c.dom.HTMLElement
-import org.w3c.dom.HTMLTableElement
+import org.w3c.dom.HTMLTableSectionElement
+import org.w3c.dom.HTMLUListElement
 import spec.*
 import kotlin.browser.window
 import kotlin.dom.appendText
 
 /**
- * A test for [tbody].
+ * A test for [tbody] and [repeatLive].
  * @author Eric Pabst (epabst@gmail.com)
  * Date: 9/29/16
  * Time: 1:51 PM
  */
 class HtmlBindTest {
     data class ListAssert(val list: List<Int>, val expectedText: String, val expectedIds: String)
+
+    @Test
+    fun repeatLiveShouldReflectData(assert: Assert) {
+        val data: Property<List<Int>?> = listOf(1).toProperty()
+        var ul: HTMLUListElement? = null
+        var nextId = 1
+        Div {
+            ul = ul {
+                repeatLive(data, NoEffect) { item ->
+                    li { id = (nextId++).toString()
+                        appendText(item.toString())
+                    }
+                }
+                li { appendText("Last") }
+            }
+        }
+        validateDataChanges(assert, ul!!, data, suffix = "Last", animate = false)
+    }
 
     @Test
     fun tableShouldReflectData(assert: Assert) {
@@ -32,61 +51,65 @@ class HtmlBindTest {
     }
 
     private fun tableShouldReflectData(assert: Assert, animate: Boolean) {
-        val done = assert.async()
         val data: Property<List<Int>?> = listOf(1).toProperty()
-        var table: HTMLTableElement? = null
+        var tbody: HTMLTableSectionElement? = null
         var nextId = 1
         Div {
-            table = table {
+            table {
                 thead {
                     th {
                         appendText("Items")
                     }
                 }
-                tbody(data, if (animate) Collapse() else NoEffect) { item ->
+                tbody = tbody(data, if (animate) Collapse() else NoEffect) { item ->
                     tr { id = (nextId++).toString()
                         td { appendText(item.toString()) }
                     }
                 }
             }
         }
-        table!!.textContent.mustBe("Items1")
-
-        val listAssertSequence = listOf(
-                ListAssert(listOf(1, 2), "Items12", "1,2"),
-                ListAssert(listOf(1, 2, 3), "Items123", "1,2,3"),
-                ListAssert(listOf(2, 3, 1), "Items231", "2,3,4"),
-                ListAssert(listOf(1, 2, 3), "Items123", "5,2,3"),
-                ListAssert(listOf(1, 3, 2), "Items132", "5,6,2"),
-                ListAssert(listOf(1, 2, 3, 4, 5, 6, 7, 8), "Items12345678", "5,7,6,8,9,10,11,12"),
-                ListAssert(listOf(1, 2, 3, 8, 7, 4, 5, 6), "Items12387456", "5,7,6,13,14,8,9,10"),
-                ListAssert(listOf(1, 2, 3, 4, 5, 6, 7, 8), "Items12345678", "5,7,6,8,9,10,16,15"),
-                ListAssert(listOf(1, 2, 3, 6, 7, 8, 4, 5), "Items12367845", "5,7,6,10,16,15,18,17"),
-                ListAssert(listOf(1, 2, 3, 6, 8, 4, 5), "Items1236845", "5,7,6,10,15,18,17"),
-                ListAssert(listOf(1, 2, 3, 4, 5), "Items12345", "5,7,6,18,17"),
-                ListAssert(listOf(5, 4, 3, 2, 1), "Items54321", "19,20,21,22,5"),
-                ListAssert(listOf(10, 11, 12, 13), "Items10111213", "23,24,25,26"),
-                ListAssert(listOf(12, 13, 14), "Items121314", "25,26,27"))
-
-        val listAssertIterator = listAssertSequence.iterator()
-        validateListAsserts(listAssertIterator, table, data, done, if (animate) 500 else 0)
+        validateDataChanges(assert, tbody!!, data, animate = animate)
     }
 
-    private fun validateListAsserts(listAssertIterator: Iterator<ListAssert>, table: HTMLTableElement?, data: Property<List<Int>?>, done: () -> Unit, stepDelay: Int) {
+    private fun validateDataChanges(assert: Assert, containerElement: HTMLElement, data: Property<List<Int>?>, suffix: String = "", animate: Boolean) {
+        val done = assert.async()
+        containerElement.textContent.mustBe("1$suffix")
+
+        val listAssertSequence = listOf(
+                ListAssert(listOf(1, 2), "12$suffix", "1,2"),
+                ListAssert(listOf(1, 2, 3), "123$suffix", "1,2,3"),
+                ListAssert(listOf(2, 3, 1), "231$suffix", "2,3,4"),
+                ListAssert(listOf(1, 2, 3), "123$suffix", "5,2,3"),
+                ListAssert(listOf(1, 3, 2), "132$suffix", "5,6,2"),
+                ListAssert(listOf(1, 2, 3, 4, 5, 6, 7, 8), "12345678$suffix", "5,7,6,8,9,10,11,12"),
+                ListAssert(listOf(1, 2, 3, 8, 7, 4, 5, 6), "12387456$suffix", "5,7,6,13,14,8,9,10"),
+                ListAssert(listOf(1, 2, 3, 4, 5, 6, 7, 8), "12345678$suffix", "5,7,6,8,9,10,16,15"),
+                ListAssert(listOf(1, 2, 3, 6, 7, 8, 4, 5), "12367845$suffix", "5,7,6,10,16,15,18,17"),
+                ListAssert(listOf(1, 2, 3, 6, 8, 4, 5), "1236845$suffix", "5,7,6,10,15,18,17"),
+                ListAssert(listOf(1, 2, 3, 4, 5), "12345$suffix", "5,7,6,18,17"),
+                ListAssert(listOf(5, 4, 3, 2, 1), "54321$suffix", "19,20,21,22,5"),
+                ListAssert(listOf(10, 11, 12, 13), "10111213$suffix", "23,24,25,26"),
+                ListAssert(listOf(12, 13, 14), "121314$suffix", "25,26,27"))
+
+        val listAssertIterator = listAssertSequence.iterator()
+        validateListAsserts(listAssertIterator, containerElement, data, done, if (animate) 500 else 0)
+    }
+
+    private fun validateListAsserts(listAssertIterator: Iterator<ListAssert>, containerElement: HTMLElement?, data: Property<List<Int>?>, done: () -> Unit, stepDelay: Int) {
         if (listAssertIterator.hasNext()) {
             val listAssert = listAssertIterator.next()
             // This callback will be called once tbody animation rendering is done
             if (data.get() != listAssert.list) {
                 data.set(listAssert.list)
                 window.setTimeout({
-                    table!!.textContent.mustBe(listAssert.expectedText)
-                    getRowIdsAsString(table).mustBe(listAssert.expectedIds)
-                    table.styleContent.mustBe("")
-                    validateListAsserts(listAssertIterator, table, data, done, stepDelay)
+                    containerElement!!.textContent.mustBe(listAssert.expectedText)
+                    getChildIdsAsString(containerElement).mustBe(listAssert.expectedIds)
+                    containerElement.styleContent.mustBe("")
+                    validateListAsserts(listAssertIterator, containerElement, data, done, stepDelay)
                 }, stepDelay)
             } else {
                 console.info("skipping since equal")
-                validateListAsserts(listAssertIterator, table, data, done, stepDelay)
+                validateListAsserts(listAssertIterator, containerElement, data, done, stepDelay)
             }
         } else {
             console.info("all validateListAsserts are done")
@@ -97,7 +120,7 @@ class HtmlBindTest {
     private val HTMLElement.styleContent: String
         get() = (getAttribute("style") ?: "") + children.toList().map { it.styleContent }.joinToString("")
 
-    private fun getRowIdsAsString(table: HTMLTableElement?): String {
-        return (table!!.lastChild!! as HTMLElement).children.toList().map { it.getAttribute("id")}.joinToString(",")
+    private fun getChildIdsAsString(containerElement: HTMLElement): String {
+        return containerElement.children.toList().map { it.getAttribute("id")}.filterNotNull().joinToString(",")
     }
 }

--- a/src/test/kotlin/net/yested/core/properties/PropertyTest.kt
+++ b/src/test/kotlin/net/yested/core/properties/PropertyTest.kt
@@ -313,6 +313,23 @@ class PropertyTest {
     }
 
     @Test
+    fun flatMapOrNull() {
+        val propertyByKey = mapOf("A" to Property("Julie"), "B" to Property("Sam"))
+        val listProperty = Property(listOf("A"))
+        val flatMapProperty = listProperty.flatMapOrNull { it.firstOrNull()?.let { propertyByKey[it] } }
+        flatMapProperty.get().mustBe("Julie")
+
+        listProperty.set(emptyList())
+        flatMapProperty.get().mustBe(null)
+
+        listProperty.set(listOf("A"))
+        flatMapProperty.get().mustBe("Julie")
+
+        propertyByKey.get("A")!!.set("Athena")
+        flatMapProperty.get().mustBe("Athena")
+    }
+
+    @Test
     fun mapWith() {
         val int1Property = 123.toProperty()
         val int2Property = 456.toProperty()

--- a/src/test/kotlin/net/yested/core/utils/SortControlTest.kt
+++ b/src/test/kotlin/net/yested/core/utils/SortControlTest.kt
@@ -76,7 +76,7 @@ class SortControlTest {
     fun shouldSortPropertyListAsExpected() {
         var nameSort : Property<Boolean?>? = null
         var ageSort : Property<Boolean?>? = null
-        val currentSort = Property<SortSpecification<Property<Person>>?>(null)
+        val currentSort = Property<SortSpecification<ReadOnlyProperty<Person>>?>(null)
         val data = listOf(Person("George", 40), Person("Ancient Billy", 90), Person("Buddy", 7)).map { it.toProperty() }.toProperty()
         val sortedData = data.sortedWith(currentSort)
         Div {


### PR DESCRIPTION
Upgrade to Kotlin 1.1.4.
Fix ClassCastException after changing the set of options for select element.
Make singleSelectInput's options be ReadOnlyProperty instead of Property.
Return the HTMLSelectElement.
Allow overriding the "Clear" label for pickadate.
Support getting a null date from pickadate.
Deprecate / instead of _ for separating hash pieces.
Make the dialog's body and footer hidden unless used.
Support ReadOnlyProperty sorting.
Add Property.mapIfNotNull, flatMapOrNull, and flatMapIfNotNull and nullProperty.
Overload setClassPresence with presentValue.
Make fun return explicit type for validator.
Provide default value for btsFormItem's state.
Add remove for List Property
Add checkbox and HTMLInputElement.bindChecked.
Add HTMLElement.repeatLive.
